### PR TITLE
Emitter (as standard lib module) (aka EventEmitter, EventTarget)

### DIFF
--- a/2013/07.md
+++ b/2013/07.md
@@ -25,11 +25,12 @@ Please register before 12th of July 2013.
   1. Approval of the minutes from May 2013 (2013/029)
   1. ECMA-262 6th Edition
     1. Status report on lastest draft (Allen)
-    1. Add fill and copySlice methods to Array.prototype and Typed Arrays http://wiki.ecmascript.org/doku.php?id=strawman:array_fill_and_move (Allen) 
+    1. Add fill and copySlice methods to Array.prototype and Typed Arrays http://wiki.ecmascript.org/doku.php?id=strawman:array_fill_and_move (Allen)
     1. Open issues discussion. (Allen)
   1. ECMA-262, Beyond the 6th Edition
     1. Object.observe/Array.observe spec changes and implementation report (Rafael - Wed or Thurs)
     1. Interfacing ECMAScript & HTML/DOM Event Loops (Rafael & Mark - Wed or Thurs)
+    1. Emitter (as standard lib module) (aka EventEmitter, EventTarget)
     1. ES7 process
     1. Private symbols
   1. ECMA-402


### PR DESCRIPTION
https://mail.mozilla.org/pipermail/es-discuss/2013-July/031734.html
