### PR TITLE
Withdraw "constructing classes without new"

### DIFF
--- a/2013/07.md
+++ b/2013/07.md
@@ -48,7 +48,6 @@ Please register before 12th of July 2013.
     1. Emitter (as standard lib module) (aka EventEmitter, EventTarget)
     1. ES7 process
     1. Private symbols
-    1. [Constructing classes without new](http://esdiscuss.org/topic/makeclassconstructorsworkwithcalltoo)
     1. Parallel JavaScript (River Trail) (Rick Hudson - any day)
     1. Value objects update (Brendan)
   1. ECMA-402


### PR DESCRIPTION
Per recent es-discuss discussions and @allenwb's "Why new Built-in constructors should not have called as factory semantics."
