### PR TITLE
Promises and lacking primitives

### DIFF
--- a/2013/07.md
+++ b/2013/07.md
@@ -56,6 +56,8 @@ Please register before 12th of July 2013.
     1. [Constructing classes without new](http://esdiscuss.org/topic/makeclassconstructorsworkwithcalltoo)
     1. Parallel JavaScript (River Trail) (Rick Hudson - any day)
     1. Value objects update (Brendan)
+    1. Promises (Anne van Kesteren - any day)
+    1. Lacking primitives: Event Streams / IO Streams / How to do lists / How to do errors / Dates (Anne van Kesteren - any day)
   1. ECMA-402
     1. Status report (Norbert)
   1. Test 262


### PR DESCRIPTION
Mozilla wants to ship promises but only if there's TC39 consensus. For web platform design we lack a bunch of primitives / design patterns that might be worth going through briefly.
