### PR TITLE
Discuss newborn generator TypeError behavior.

### DIFF
--- a/2014/01.md
+++ b/2014/01.md
@@ -35,6 +35,7 @@ Please register before 21st of January 2014.
     5. Discuss convening a security review of module loaders & realms (MarkM, Kevin, Allen)
     6. Compatibility semantics of functions in blocks (Luke, Brian)
     7. Don't throw on Array.from(undefined), default to empty array (Rick, Brian) https://bugs.ecmascript.org/show_bug.cgi?id=2435
+    8. Consider not throwing a `TypeError` when `.next(value)` is called on a newborn generator that delegates to a non-newborn generator using `yield*` (Ben Newman)
   1. ECMA-262 7th Edition
     1. Structured Clone (Anne van Kesteren, Dmitry Lomov)
     1. Typed objects update (Dmitry Lomov, Niko Matsakis) 


### PR DESCRIPTION
I would like to establish a convention that

``` js
function *wrapper() {
  return yield* delegate;
}
```

is the best way to create a wrapper generator function around an existing generator object (`delegate`) such that the generator object created by `wrapper()` behaves as much like `delegate` as possible.

This goal of transparent wrapping is inspired by the long-standing JS convention that

``` js
function wrapper() {
  return fn.apply(this, arguments);
}
```

is the best way to create a wrapper function that behaves like `fn`.

The current specification _almost_ provides this transparency, with one exception: the object created by `wrapper()` is necessarily a newborn generator, whereas `delegate` might not be a newborn generator.

I think we might want to relax the language about throwing a `TypeError` when `wrapper().next(value)` is called with `typeof value !== "undefined"`, since that `value` might be of interest to the `delegate` generator.
