### PR TITLE
Fix markdown syntax

### DIFF
--- a/2014/04.md
+++ b/2014/04.md
@@ -43,7 +43,7 @@ Please register before 1st of April 2014.
     1. Consider changing [[OwnPropertyKeys]] return type from iterator to array and include invariant checks (Tom VC)
       1. http://esdiscuss.org/topic/object-getownpropertydescriptors-o-plural#content-34
     1. Finalize default argument semantics (arguments object mapping, TDZ, scoping) (Brian Terlson)
-    1. Object.prototype.__proto__ = proxy footgun (Brian Terlson)
+    1. `Object.prototype.__proto__ = proxy` footgun (Brian Terlson)
     1. Module Feedback from MSFT (Brian Terlson)
   1. ECMA-262 7th Edition
     1. Object.entries(), Object.values() (Rick Waldron)


### PR DESCRIPTION
Avoid `Object.prototype.<b>proto</b>`
