### PR TITLE
Update 05.md

### DIFF
--- a/2015/05.md
+++ b/2015/05.md
@@ -35,6 +35,7 @@
   1. ECMA-402 2nd Edition
   1. Post ES6 process,  roles. and targets
   1. ECMA-262 7th Edition and beyond
+    1. Module export-from additions - Move to stage 3? [Draft Spec](https://github.com/leebyron/ecmascript-more-export-from) (Lee Byron - Facebook)
     1. SIMD.js - Move to stage 2? Docs: [Draft Spec](http://johnmccutchan.github.io/ecmascript_simd/tc39/simd.html),  [Polyfill](https://github.com/johnmccutchan/ecmascript_simd), [Presentation](). (Peter Jensen - Intel, John Mccutchan - Google, Dan Gohman - Mozilla)
     1. function.next meta-property - Move to Stage 2? Docs: [Proposal including spec. language](https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md) (Allen)
     1. Observable Nominal Type Strawman, [Polyfill](https://github.com/zenparsing/es-observable). (Jafar Husain - Netflix, Kevin Smith)


### PR DESCRIPTION
Since our last TC39 meeting, the spec text for export-from additions have been fully specified, ample discussion has happened with module proposal champions, and babel has included transpilers for them. I'd like to get this on the agenda to discuss advancing from stage 1 to stage 2 or 3.