### PR TITLE
Adding link to Observable spec

### DIFF
--- a/2015/07.md
+++ b/2015/07.md
@@ -34,8 +34,7 @@
      1. Introduce (and maybe advance?) [RegExp.escape proposal](https://github.com/benjamingr/RegExp.escape) (Domenic Denicola)
      1. Introduce [promise rejection tracking proposal](https://github.com/domenic/unhandled-rejections-browser-spec#changes-to-ecmascript) (Domenic Denicola)
      1. Advance Async Functions to Stage 2 & discuss open questions (Brian Terlson)
-     1. Generators and scarce resource disposal 
-     1. Proposed Observable API
+     1. Proposed Changes to Observable API (https://github.com/zenparsing/es-observable/tree/zenlike)
      1. BindingRestElement should allow a BindingPattern ala AssignmentRestElement (Brian Terlson)
      1. `new` & GeneratorFunction (Brian Terlson)
      1. SIMD.js: Start the process to move towards Stage 3 ([spec](http://littledan.github.io/simd.html)) (Dan Gohman, John Mccutchan, Peter Jensen, Daniel Ehrenberg) 


### PR DESCRIPTION
...detailing proposed changes to Observable spec. Also removing topic (scarce resource disposal in generators) in apprehension of discussing it during Promise cancellation.