### PR TITLE
Add class properties to agenda (again)

### DIFF
--- a/2015/09.md
+++ b/2015/09.md
@@ -40,6 +40,7 @@
      1. Proposal: Shared memory and atomics (Lars T Hansen, Mozilla) [Proposal materials on github](https://github.com/lars-t-hansen/ecmascript_sharedmem)
      1. SIMD.js Stage 3 proposal (Daniel Ehrenberg, John McCutchan, Peter Jensen, Dan Gohman) [draft specification](http://tc39.github.io/ecmascript_simd/)
      2. Async Functions Stage 3 proposal (Brian Terlson) [draft specification](http://tc39.github.io/ecmascript-asyncawait)
+     3. Updates on [class-properties proposal](https://github.com/jeffmo/es-class-properties) (Jeff Morrison)
   1. Test262 Updates
   1. ECMA-402 3rd Edition, 2016
   1. Tooling Updates (Brian Terlson)


### PR DESCRIPTION
Seems to have been removed in https://github.com/tc39/agendas/commit/ec97e0f5922320fa98d5700ed7b85545cc7a58e3