### PR TITLE
Add `Object.{values,entries}` + `String#{padLeft,padRight}` to agenda

### DIFF
--- a/2015/11.md
+++ b/2015/11.md
@@ -34,9 +34,11 @@
 1.  Report from the Ecma Secretariat
 1. Proposals for Future Editions of ECMA-262
   1. [Promise rejection tracking events](https://github.com/tc39/ecma262/pull/76) (Domenic Denicola - Google)
-  2. [Simplification of ES2015 RegExp Semantics](https://github.com/tc39/ecma262/pull/89) (Brian Terlson - Microsoft, Daniel Ehrenberg - Google)
-  3. [Should destructuring declarations without bindings throw](https://github.com/tc39/ecma262/issues/97) (Brian Terlson - Microsoft)
-  4. Update on [Object.observe proposal](https://github.com/arv/ecmascript-object-observe) (Adam Klein)
+  1. [Simplification of ES2015 RegExp Semantics](https://github.com/tc39/ecma262/pull/89) (Brian Terlson - Microsoft, Daniel Ehrenberg - Google)
+  1. [Should destructuring declarations without bindings throw](https://github.com/tc39/ecma262/issues/97) (Brian Terlson - Microsoft)
+  1. Update on [Object.observe proposal](https://github.com/arv/ecmascript-object-observe) (Adam Klein)
+  1. Advance [Object.values/Object.entries proposal](https://github.com/tc39/proposal-object-values-entries) to stage 3 (Jordan Harband)
+  1. Advance [String#{padLeft,padRight} proposal](https://github.com/tc39/proposal-string-pad-left-right) to stage 2 (3 if possible) (Jordan Harband)
 1. Test262 Updates
 1. ECMA-402 3rd Edition, 2016
 1.  Date and place of the next meetings


### PR DESCRIPTION
I also fixed the markdown lists, which should always use "1" for easier reordering.