### PR TITLE
Add agenda item for Symbol.species improvements.

### DIFF
--- a/2015/11.md
+++ b/2015/11.md
@@ -60,6 +60,7 @@ Please register here (https://ecma-international.doodle.com/poll/fubwuawp6zu3q4y
   1. Stage 2 approval for [class and property decorators](https://github.com/wycats/javascript-decorators) (Yehuda Katz - jQuery, Brian Terlson, Microsoft)
   1. GitHub Proposal Process Discussion: When to migrate to official repo?
   1. Proxy [[Enumerate]] overconstrains implementations (Brian Terlson - Microsoft)
+  1. Improving consistency of `@@species`. [1](https://esdiscuss.org/topic/resolve-reject-on-promise-subclasses-and-species#content-1) [2](https://github.com/zenparsing/es-observable/issues/69#issuecomment-154456842) (Kevin Smith)
 1. Test262 Updates
 1. ECMA-402 3rd Edition, 2016
 1.  Date and place of the next meetings


### PR DESCRIPTION
There are some consistency issues with how Symbol.species is used across the different built-ins, and there are some questions about whether new built-in constructors that support subclassing should have a species method.  Also, there is a suggestions that it might be better just to put a default Symbol.species implementation on Function.prototype.