### PR TITLE
add March 2015 skeleton agenda

### DIFF
--- a/2016/03.md
+++ b/2016/03.md
@@ -1,0 +1,54 @@
+<img src="../images/Ecma_RVB-003.jpg" align="right" height="70" alt="" />
+
+## Agenda for the 51st meeting of Ecma TC39
+
+    HOST: Mozilla - San Francisco
+    DATES: 29 March 2016 to 31 March 2016
+    TIMES:
+      10:00 to 17:00 PDT on 29 and 30 March 2016
+      10:00 to 16:00 PDT on 31 March 2016
+    LOCATION:
+      TBD
+    WIFI:
+      TBD
+    TUESDAY DINNER:
+      Time: TBD
+      Location: TBD
+    WEDNESDAY DINNER:
+      Time: TBD
+      Location: TBD
+    CONTACT:
+      Name: TBD
+      Phone: TBD
+      Email: TBD
+
+## Logistics
+
+- [Registration Link](https://ecma-international.doodle.com/poll/...)
+- [Map of nearby reputable hotels](https://www.google.com/maps/...)
+
+## Agenda items
+
+1. Opening, welcome and roll call
+  1. Opening of the meeting (Mr. Neumann)
+  1. Introduction of attendees
+  1. Host facilities, local logistics
+1. Adoption of the agenda
+1. Approval of the minutes from January 2016
+1. Report from the Ecma Secretariat
+1. Proposals for future editions of ECMA-262
+  1. Existing proposals looking to advance
+  1. New proposals and updates on existing proposals
+1. Test262 updates
+1. ECMA-402 updates
+1. Closure
+
+## Dates and locations of future meetings
+
+| Dates                    | Location          | Host       |
+|--------------------------|-------------------|------------|
+| 2016-05-23 to 2016-05-25 | Munich, DE        | Google     |
+| 2016-07-26 to 2016-07-28 | Remond, WA        | Microsoft  |
+| 2016-09-27 to 2016-09-29 | Los Gatos, CA     | Netflix    |
+| 2016-11-29 to 2016-12-01 | Menlo Park, CA    | Facebook   |
+


### PR DESCRIPTION
I left location/event info TBD, but wanted to get this in so we can start accepting PRs for agenda items. I took the liberty of setting the height of the Ecma logo so that it no longer obstructs the meeting details, and pulled the dates/locations of future meetings table out of the agenda items.