### PR TITLE
Reorganize and duplicate FiB

### DIFF
--- a/2016/03.md
+++ b/2016/03.md
@@ -47,19 +47,22 @@
   1. ECMA-402 3rd Edition: ECMAScript 2016 Internationalization API (Caridy Patiño)
   1. New Standard: ECMAScript Language Suite (Allen Wirfs-Brock)
 1. Proposals for future editions of ECMA-262
-  1. Existing proposals looking to advance
-    1. [Async Iteration](https://tc39.github.io/proposal-async-iteration/)
+  1. Pull requests
+    1. [Length argument normalization for TypedArrays, ArrayBuffer and DataView constructors](https://github.com/tc39/ecma262/pull/410#issuecomment-199472826) (Leo Balter)
+    1. [Duplicate sloppy mode function in block web compatibility fix](https://github.com/tc39/ecma262/pull/400) (Shu-yu Guo and Daniel Ehrenberg)
+  1. Existing proposals looking to advance to Stage 1 or beyond
+    1. [Async Iteration](https://tc39.github.io/proposal-async-iteration/) (Kevin Smith)
     1. [Function.prototype.toString revision](http://tc39.github.io/Function-prototype-toString-revision/) (Michael Ficarra)
     1. [Async Functions](https://tc39.github.io/ecmascript-asyncawait) (Brian Terlson)
-  1. New proposals and updates on existing proposals
-    1. [Private Fields](https://zenparsing.github.io/es-private-fields/)
-    1. [Zones](https://github.com/domenic/zones) update ([spec](https://domenic.github.io/zones/))
-    1. [Weak References](https://github.com/tc39/proposal-weakrefs)
-    1. [SES: Secure EcmaScript](https://github.com/FUDCo/ses-realm)
+  1. Status updates on existing proposals not looking to advance
+    1. [Zones](https://github.com/domenic/zones) update ([spec](https://domenic.github.io/zones/)) (Domenic Denicola, Misko Hevery)
+    1. [Shared Memory and Atomics](https://github.com/tc39/ecmascript_sharedmem) (Lars Hansen)
+  1. New proposals for Stage 1
+    1. [Private Fields](https://zenparsing.github.io/es-private-fields/) (Kevin Smith)
+    1. [Weak References](https://github.com/tc39/proposal-weakrefs) (Dean Tribble)
+    1. [SES: Secure EcmaScript](https://github.com/FUDCo/ses-realm) (Mark Miller)
     1. [Lifting TemplateCharacter Restrictions](https://github.com/disnet/template-literal-revision) (Tim Disney)
-    1. [Shared Memory and Atomics](https://github.com/tc39/ecmascript_sharedmem)
-    1. [Agents (spun out from Shared Memory and Atomics) (tentative)](https://axis-of-eval.org/shmem/agents-formatted.html)
-    1. [Length argument normalization for TypedArrays, ArrayBuffer and DataView constructors](https://github.com/tc39/ecma262/pull/410#issuecomment-199472826)
+    1. [Agents (spun out from Shared Memory and Atomics) (tentative)](https://axis-of-eval.org/shmem/agents-formatted.html) (Lars Hansen)
 1. Test262 updates
     1. aggregated FOSS parser pass-fail and equivalence tests (Kevin Gibbons)
 1. ECMA-402 updates


### PR DESCRIPTION
This patch puts authors on each proposal and groups the topics into four categories. I'm making this as a PR so others can review the change first.