### PR TITLE
move "class field initializers" agenda item to appropriate section

### DIFF
--- a/2016/05.md
+++ b/2016/05.md
@@ -54,12 +54,11 @@ Be aware that the office has no parking space.
 1. Proposals for future editions of ECMA-262
   1. Existing proposals looking to advance
     1. [Observable](https://github.com/zenparsing/es-observable) (Kevin Smith and Jafar Husain)
-    1. [Class Field Initializers: `this` semantics](https://github.com/jeffmo/es-class-fields-and-static-properties/issues/34) (Jeff Morrison)
     1. [Lifting Template Literal Restriction](https://github.com/disnet/template-literal-revision) (Tim Disney)
   1. New proposals
     1. [Legacy RegExp features](https://github.com/claudepache/es-regexp-legacy-static-properties) (by [Claude Pache](https://github.com/claudepache). Championed by [Mark S. Miller](https://github.com/erights))
-
   1. Updates on existing proposals
+    1. [Class Field Initializers: `this` semantics](https://github.com/jeffmo/es-class-fields-and-static-properties/issues/34) (Jeff Morrison)
 1. Test262 updates
 1. ECMA-402 updates
 1. JSExplain: towards a spec debugger (Alan Schmitt)


### PR DESCRIPTION
See https://github.com/tc39/agendas/commit/e2537631585be6a193c7e02b86dcbee81a67eaf8#commitcomment-17361742.

@jeffmo 