### PR TITLE
Proposal to discuss nested `import` declarations

### DIFF
--- a/2016/07.md
+++ b/2016/07.md
@@ -48,6 +48,7 @@
     1. [Object.enumerable{Keys,Values,Entries}](https://github.com/leobalter/object-enumerables) (Leo Balter)
     1. [RegExp Unicode Property Escapes](https://github.com/mathiasbynens/es-regex-unicode-property-escapes) (championed by Brian Terlson and Daniel Ehrenberg, text by Mathias Bynens)
     1. [Unambiguous ES Module Grammar](https://github.com/bmeck/UnambiguousJavaScriptGrammar) (Bradley Farias and John-David Dalton)
+    1. [Nested `import` declarations](https://github.com/benjamn/reify/blob/master/WHY_NEST_IMPORTS.md) (Ben Newman, Meteor)
   1. Updates on existing proposals
     1. [Class Field Initializers: `this` semantics](https://github.com/jeffmo/es-class-fields-and-static-properties/issues/34) (Jeff Morrison)
 1. Test262 updates


### PR DESCRIPTION
I'd like to present what I've learned from writing a new [transpiler](https://github.com/benjamn/reify) for ES2015 modules that does not restrict `import` declarations to the top level.

I think I can construct a convincing case for allowing nested `import` declarations, but I'm also sure I do not know all the relevant history that has gone into the current spec, which effectively restricts them to the top level.

Please have a look at the linked [document](https://github.com/benjamn/reify/blob/master/WHY_NEST_IMPORTS.md) before the July meeting (if this topic interests you), and let me know if it comes close to addressing your concerns. I'm happy to revise it or write a completely different sort of document, if folks prefer.

cc @dherman @caridy et al.