### PR TITLE
Remove Unambiguous Module Grammar from July agenda.

### DIFF
--- a/2016/07.md
+++ b/2016/07.md
@@ -62,7 +62,6 @@
     1. [Legacy RegExp features](https://github.com/claudepache/es-regexp-legacy-static-properties) (by [Claude Pache](https://github.com/claudepache). Championed by [Mark S. Miller](https://github.com/erights))
     1. [Promise.prototype.finally](https://github.com/ljharb/proposal-promise-finally) (overlaps cleanly with Cancelable Promises proposal) (Jordan Harband)
     1. [RegExp Unicode Property Escapes](https://github.com/mathiasbynens/es-regex-unicode-property-escapes) (championed by Brian Terlson and Daniel Ehrenberg, text by Mathias Bynens)
-    1. [Unambiguous ES Module Grammar](https://github.com/bmeck/UnambiguousJavaScriptGrammar) (Bradley Farias and John-David Dalton)
     1. [Nested `import` declarations](https://github.com/benjamn/reify/blob/master/WHY_NEST_IMPORTS.md) (Ben Newman, Meteor)
   1. Discussion & Updates for Existing Proposals
     1. [Class Field Initializers: `this` semantics](https://github.com/jeffmo/es-class-fields-and-static-properties/issues/34) (Jeff Morrison)


### PR DESCRIPTION
Since [UnambiguousJavaScriptGrammar](https://github.com/bmeck/UnambiguousJavaScriptGrammar) was just accepted as [section 5.1](https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md#51-determining-if-source-is-an-es-module) of the [Node ES6 Module Interoperability](https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md) draft proposal I'm removing this item to give us time to get our feet wet, coordinate, and prepare a discussion at the Sept. TC39 meeting.