### PR TITLE
Link to nested `import` pull request rather than sales pitch

### DIFF
--- a/2016/07.md
+++ b/2016/07.md
@@ -75,7 +75,7 @@
   1. New Proposals
     1. [Legacy RegExp features](https://github.com/claudepache/es-regexp-legacy-static-properties) (by [Claude Pache](https://github.com/claudepache). Championed by [Mark S. Miller](https://github.com/erights))
     1. [Promise.prototype.finally](https://github.com/ljharb/proposal-promise-finally) (overlaps cleanly with Cancelable Promises proposal) (Jordan Harband)
-    1. [Nested `import` declarations](https://github.com/benjamn/reify/blob/master/WHY_NEST_IMPORTS.md) (Ben Newman, Meteor)
+    1. [Nested `import` declarations](https://github.com/tc39/ecma262/pull/646) (Ben Newman, Meteor Development Group)
     1. [Object.shallowEqual](https://github.com/sebmarkbage/ecmascript-shallow-equal) (Sebastian Markbage)
   1. Discussion & Updates for Existing Proposals
     1. [Class Field Initializers: `this` semantics](https://github.com/jeffmo/es-class-fields-and-static-properties/issues/34) (Jeff Morrison)


### PR DESCRIPTION
The original document had the tone of an informal sales pitch. I'm sorry if anyone read it and was bothered by that.

The pull request (and linked proposal) have been rewritten to be more appropriate for TC39, including work-in-progress changes to the specification itself.