### PR TITLE
Add September agenda, prepopulated with overflow items from July meeting

### DIFF
--- a/2016/09.md
+++ b/2016/09.md
@@ -1,0 +1,79 @@
+<img src="../images/Ecma_RVB-003.jpg" align="right" height="70" alt="" />
+
+## Agenda for the 54th meeting of Ecma TC39
+
+- **Host**: Netflix, Los Gatos, CA
+- **Dates**: *Tuesday*, 27 September 2016 to *Thursday*, 29 September 2016
+- **Times**:
+  - 10:00 to 17:00 PDT on TBD
+  - 10:00 to 16:00 PDT on TBD
+- **Location**: TBD
+- **Wifi**: TBD
+- **Dinner**: TBD
+- **Contact**:
+  - Name: TBD
+  - Phone: TBD
+  - Email: TBD
+
+## Logistics
+
+* Where to park
+* How to access the building
+* Technical presentation requirements (adapters, google hangouts/other accounts required, etc.)
+* Any other logistics required to participate in the meeting
+
+### Registration
+
+TBD
+
+### Hotels
+
+TBD Hotels nearby (optional)
+
+## Agenda items
+
+1. Opening, welcome and roll call
+  1. Opening of the meeting (Mr. Neumann)
+  1. Introduction of attendees
+  1. Host facilities, local logistics
+1. Find volunteers for note taking
+1. Adoption of the agenda
+1. Approval of the minutes from last meeting
+1. Report from the Ecma Secretariat (15m)
+1. ECMA262 Status Updates (15m)
+1. ECMA402 Status Updates (15m)
+1. Test262 Status Updates (15m)
+1. Timeboxed overflow from previous meeting
+  1. 15 Minute Items
+  1. 30 Minute Items
+    1. [Legacy RegExp features](https://github.com/claudepache/es-regexp-legacy-static-properties) (by [Claude Pache](https://github.com/claudepache). Championed by [Mark S. Miller](https://github.com/erights))
+  1. 45 Minute Items
+  1. 60 Minute Items
+    1. [Private state](https://github.com/tc39/proposal-private-fields) ([slides](https://docs.google.com/presentation/d/1RM_DEWAYh8PmJRt02IunIRaUNjlwprXF3yPW6NltuMA/edit)) (Daniel Ehrenberg)
+  1. Timebox Not Yet Selected
+    1. [Unify String and Array maximum lengths](https://github.com/tc39/ecma262/pull/641) (Michael Saboff)
+    1. [Standardize Date.UTC when called with 1 argument](https://github.com/tc39/ecma262/pull/642) (Brian Terlson)
+    1. [Revisit NaN again!](https://github.com/tc39/ecma262/issues/635) ([slides](https://docs.google.com/presentation/d/1eqimbmVpMZET_5H9NacVkXGP2WNATg8bXWi3Ky2bsGo/edit)) (Daniel Ehrenberg)
+    1. [Rest/Spread Properties](http://sebmarkbage.github.io/ecmascript-rest-spread/) to stage 3. (Sebastian Markbage)
+1. Timeboxed agenda items
+  1. 15 Minute Items
+  1. 30 Minute Items
+  1. 45 Minute Items
+  1. 60 Minute Items
+1. Non-timeboxed agenda items
+  1. Stage 0+ proposals looking to advance
+  1. New proposals
+  1. Discussion and updates for Stage 0+ Proposals
+1. Overflow from timeboxed discussion items (in insertion order)
+1. Closure
+
+### Agenda Topic Rules
+
+1. Proposals looking to advance must be added to the agenda along with necessary review materials 7 days prior to the first day of the meeting.
+1. Timeboxed topics may be 15, 30, 45, or 60 minutes in length.
+
+## Dates and locations of future meetings
+
+| Dates                    | Location          | Host       |
+|--------------------------|-------------------|------------|
+| 2016-11-29 to 2016-12-01 | Menlo Park, CA    | Facebook   |


### PR DESCRIPTION
 - Legacy RegEx Features champion verbally confirmed 30 minutes (@erights)
 - Private State champion verbally confirmed 60 minutes (@littledan)

The “Timebox Not Yet Selected” items’ champions (@msaboff, @bterlson, @littledan, @sebmarkbage) will need to either select a timebox, remove their proposal from the agenda, or move their proposal to the appropriate un-timeboxed category, ideally at least a few weeks prior to the September meeting.