### PR TITLE
Node.js ecosystem compatibility breaks w/ ES Modules

### DIFF
--- a/2016/09.md
+++ b/2016/09.md
@@ -80,6 +80,7 @@
   1. New proposals
     1. [Promise.try](https://github.com/ljharb/proposal-promise-try) to stage 1 (possibly 2?) (Jordan Harband)
     1. [RegExp `s`/`dotAll` flag](https://github.com/mathiasbynens/es-regexp-dotall-flag) to stage 1 (possibly 2?) (championed by Brian Terlson, text by Mathias Bynens)
+  1. Node.js ecosystem compatibility breaks w/ ES Modules (Mikeal Rogers)
   1. [Proposed Grammar change to ES Modules](https://github.com/bmeck/UnambiguousJavaScriptGrammar) (Bradley Farias)
   1. Discussion and updates for Stage 0+ Proposals
 1. Overflow from timeboxed discussion items (in insertion order)


### PR DESCRIPTION
I'll be attending this meeting as an invited expert, primarily to cover this topic.

The Node.js Foundation CTC along with Bradley Meck and many others have been diving deep into what it will take to implement ES Modules in Node.js. The current state of the spec, if unmodified, leaves Node.js in a position where implementing it "as is" would cause compatibility breaks with the existing module system that the Node.js project is not willing to make.

Without spec changes Node.js will be forced to implement the new ES Modules support in a way that is not entirely compatible with the spec as well as rely on out of spec behaviors like .jsm file extensions.

I'll be attending to try to represent the project consensus thus far and we are also making sure that several of the other member companies are sending their Node.js contributors as well.