### PR TITLE
+ Consolidating Proxy integrity checks

### DIFF
--- a/2016/09.md
+++ b/2016/09.md
@@ -83,6 +83,7 @@
     1. Update on integrating [Observable](https://docs.google.com/presentation/d/18KkpDm0Z-lGnUFxcK_ZJwSKCSalnBqjhGN8W--PyT88/edit?usp=sharing) with Cancel Tokens (Jafar Husain).
   1. 60 Minute Items
     1. [Cancelable promises](https://github.com/tc39/proposal-cancelable-promises) for stage 2 (Domenic Denicola)
+    1. Consolidating Proxy integrity checks, see [PR 666](https://github.com/tc39/ecma262/pull/666) and [claudepache/es-invariants](https://github.com/claudepache/es-invariants) (Claude Pache) **should be on Wednesday morning**
 1. Non-timeboxed agenda items
   1. Web compatibility issues / Needs-consensus PRs
     1. [Remove arguments.caller](https://github.com/tc39/ecma262/pull/689) (Brian Terlson)


### PR DESCRIPTION
@erights @tvcutsem @bterlson 

Sorry for being late. This is what I intend to present.

* missing integrity checks for Proxies https://github.com/tc39/ecma262/pull/666, and convincing that these checks are all is needed (summary of [claudepache/es-invariants](https://github.com/claudepache/es-invariants));
* if I have time to prepare and present it: if the TargetObject of a Proxy is itself a Proxy, do the integrity checks on the TargetObject of the TargetObject;
* I don’t think I’ll have time for it: Possible solution to: https://esdiscuss.org/topic/the-invariants-of-the-essential-methods-are-false-in-case-of-reentrancy.
* ***Not included*** — and it would be great if someone else could take it: Ensure that \[\[OwnPropertyKeys]]() does not return duplicate keys, see https://github.com/tc39/ecma262/issues/461.

