### PR TITLE
using root license as default for test files on test262

### DIFF
--- a/2017/03.md
+++ b/2017/03.md
@@ -58,6 +58,7 @@ TBD
         1. [SIMD.js](https://github.com/tc39/ecmascript_simd/) status update (Daniel Ehrenberg)
         1. [ECMA402](https://github.com/tc39/ecma402/) Presentation of the three formatters for stage 2 (Zibi Braniecki)
         1. [Intl.Segmenter](https://github.com/tc39/proposal-intl-segmenter) for requesting Stage 3 reviewers (Daniel Ehrenberg, Leo Balter) ([slides](https://docs.google.com/presentation/d/1BnVToKOybjLh7IPa6k1i1ruLysFDKIVgo5heU1qb7CM/edit))
+        1. Test262: [using root license as default for files](https://github.com/tc39/test262/pull/851) (Leo Balter)
     1. 30 Minute Items
         1. [Observable proposal](https://github.com/tc39/proposal-observable) for Stage 2 (Jafar Husain, Mark Miller)
         1. [Dynamic Module Reform](https://github.com/caridy/proposal-dynamic-modules) for Stage 2 (Caridy Patiño, Dave Herman)


### PR DESCRIPTION
This is about a Test262 need consensus PR, I want to limit it to 15 minutes max and preferrably not address this item during the test262 updates, which I've got a lot of other things to mention.