### PR TITLE
Add export-default-from and export-ns-from to 2017/07 agenda.

### DIFF
--- a/2017/07.md
+++ b/2017/07.md
@@ -62,6 +62,7 @@ No recommendations. Many are available. Check with your travel agent.
         1. [Symbol.prototype.description](https://michaelficarra.github.io/Symbol-description-proposal/) (Michael Ficarra)
         1. [Promise.prototype.finally](https://github.com/tc39/proposal-promise-finally/) seeking stage 3 (Jordan Harband)
         1. [Intl.RelativeTimeFormat](https://github.com/tc39/proposal-intl-relative-time) for Stage 2 (Zibi Braniecki, Daniel Ehrenberg)
+        1. [export-default-from](https://github.com/tc39/proposal-export-default-from) and [export-ns-from](https://github.com/tc39/proposal-export-ns-from) for Stage 2 (Ben Newman, John-David Dalton)
     1. 45 Minute Items
         1. [BigInt](https://github.com/tc39/proposal-bigint) for Stage 3 (Daniel Ehrenberg)
         1. [Array.prototype.{flatMap,flatten}](https://github.com/tc39/proposal-flatMap) (Brian Terlson, Michael Ficarra)


### PR DESCRIPTION
Adding the [export-default-from](https://github.com/tc39/proposal-export-default-from) and [export-ns-from](https://github.com/tc39/proposal-export-ns-from) to the 2017/07 agenda.