### PR TITLE
Add "referential destructuring" proposal to 30min-boxed items.

### DIFF
--- a/2017/09.md
+++ b/2017/09.md
@@ -102,6 +102,7 @@ Allen's paper on standards committee participation for new attendees: http://wir
         1. [Throw Expressions](https://github.com/rbuckton/proposal-throw-expressions) for Stage 2 (Ron Buckton) ([slides](https://rbuckton.github.io/proposal-throw-expressions/ThrowExpressions-tc39.pptx), [spec](https://rbuckton.github.io/proposal-throw-expressions/))
         1. [`do`-expressions](https://github.com/tc39/proposal-do-expressions) update (Dave Herman)
         1. [Ergonomic Cancellation Through Async Calls](https://docs.google.com/presentation/d/1Lg_chkGiugx69yXKwr5Vrg4Xmxt7Tui0kmUFFZx1KNs/edit?usp=sharing) (Yehuda Katz, David Herman)
+        1. [Referential destructuring](https://github.com/meteor/proposal-referential-destructuring) for Stage 1 (Ben Newman)
     1. 45 Minute Items
         1. [String.prototype.matchAll](https://github.com/tc39/proposal-string-matchall/pull/17) for Stage 2 (Jordan Harband)
         1. Optional chaining operator for Stage 2 (Claude Pache, Gabriel Isenberg) ([spec](https://tc39.github.io/proposal-optional-chaining/), [explainer](https://github.com/tc39/proposal-optional-chaining) [slides](https://docs.google.com/presentation/d/1iiCtJSW42Z7lg0YlagOZOfI-FTrkN88OuiO3pySawSo/edit?usp=sharing))


### PR DESCRIPTION
This is a new (Stage 0) proposal of a feature that should improve the usability of dynamic `import()`, and whose adoption would persuade me to abandon my old [nested `import` declarations](https://github.com/tc39/ecma262/pull/646) proposal.

Please see the linked [proposal text](https://github.com/meteor/proposal-referential-destructuring/blob/master/README.md) for more information. I believe it meets the requirements for Stage 1.