### PR TITLE
Move my topics to the end of their sections

### DIFF
--- a/2017/11.md
+++ b/2017/11.md
@@ -86,34 +86,34 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. [Numeric separators](https://github.com/tc39/proposal-numeric-separator) for Stage 3 (Sam Goto, Rick Waldron)
         1. [RegExp named captures](https://github.com/tc39/proposal-regexp-named-groups) for Stage 4 (Mathias Bynens)
         1. [RegExp lookbehind assertions](https://github.com/tc39/proposal-regexp-lookbehind) for Stage 4 (Mathias Bynens)
-        1. [BigInt](https://github.com/tc39/proposal-bigint) status update (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1u2xXRokUBPMjBsTL_ZCDghA16cH5FI0m1kLOczm1oMw/edit#slide=id.p))
-        1. [Intl.ListFormat](https://github.com/tc39-transfer/proposal-intl-list-format) find Stage 3 reviewers (Daniel Ehrenberg)
         1. InterpreterDirective (Bradley Farias) ([gist](https://gist.github.com/bmeck/59cf8c16959eccffd8b7e9828826a842))
         1. [`String.prototype.codePoints`](https://github.com/RReverser/string-prototype-codepoints) for Stage 1 (Ingvar Stepanyan, Mathias Bynens)
         1. [`String.prototype.replaceAll`](https://github.com/psmarshall/string-replace-all-proposal) for Stage 1 (Mathias Bynens)
         1. [Throw expressions](https://github.com/tc39/proposal-throw-expressions#readme) request for reviewers for Stage 3 (Brian Terlson, Ron Buckton).
         1. Additional Intl options, for addition by [needs-consensus PR](https://github.com/tc39/ecma402/pull/175) (Daniel Ehrenberg) ([some](https://github.com/tc39/ecma402/issues/163) [possible](https://github.com/tc39/ecma402/issues/186) [further](https://github.com/tc39/ecma402/issues/95) [options](https://github.com/tc39/ecma402/issues/164))
+        1. [BigInt](https://github.com/tc39/proposal-bigint) status update (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1u2xXRokUBPMjBsTL_ZCDghA16cH5FI0m1kLOczm1oMw/edit#slide=id.p))
+        1. [Intl.ListFormat](https://github.com/tc39-transfer/proposal-intl-list-format) find Stage 3 reviewers (Daniel Ehrenberg)
     1. 30 Minute Items
         1. [RegExp Unicode property escapes](https://github.com/tc39/proposal-regexp-unicode-property-escapes) for Stage 4 (Mathias Bynens)
         1. [Make ECMAScript a syntactic superset of JSON](https://github.com/gibson042/ecma262-proposal-json-superset) for Stage 2 (by Richard Gibson. Championed by Mark S. Miller & Mathias Bynens)
-        1. [Intl.Locale](https://github.com/tc39/proposal-intl-locale) for Stage 2 (Daniel Ehrenberg)
-        1. Clarify/redefine Stage 4 requirements (Daniel Ehrenberg) ([PR](https://github.com/tc39/process-document/pull/15))
-        1. [Pipeline Operator](https://github.com/tc39/proposal-pipeline-operator) for Stage 2 (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/112oOoEQi1v-uP1jSVWVHCAK7oPA15VX_UP_yarzMeLI/edit#slide=id.p))
-        1. [Allow await in non-arrow async function parameter defaults](https://github.com/tc39/ecma262/issues/917) (Daniel Ehrenberg)
         1. Revisiting parameter initializers and sloppy eval (Adam Klein) ([gist](https://gist.github.com/ajklein/b947351835cc77ad0040db9a55813f51))
         1. Discuss module order instantiation/evaluation guarantees (Bradley Farias) ([slides](https://docs.google.com/presentation/d/1RXvvScD8ce2FyLY2aYhbas83WCiBqzIOqdMt4OpkCJM/view))
         1. Repair loss of Proxy transparency, for Stage 1 (Mark S. Miller, Caridy Patino, Keith Miller, Tom Van Cutsem) ([issue thread](https://github.com/tvcutsem/es-lab/issues/21))
         1. Array`[@@Species]`, Array Index Accessors and Security (Natalie Silvanovich)
+        1. [Intl.Locale](https://github.com/tc39/proposal-intl-locale) for Stage 2 (Daniel Ehrenberg)
+        1. Clarify/redefine Stage 4 requirements (Daniel Ehrenberg) ([PR](https://github.com/tc39/process-document/pull/15))
+        1. [Pipeline Operator](https://github.com/tc39/proposal-pipeline-operator) for Stage 2 (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/112oOoEQi1v-uP1jSVWVHCAK7oPA15VX_UP_yarzMeLI/edit#slide=id.p))
+        1. [Allow await in non-arrow async function parameter defaults](https://github.com/tc39/ecma262/issues/917) (Daniel Ehrenberg)
         1. [What is the motivation for private fields being per class execution?](https://github.com/tc39/proposal-class-fields/issues/60) (Daniel Ehrenberg)
     1. 45 Minute Items
         1. [Block Params](https://github.com/samuelgoto/proposal-block-params) to Stage 1 (Sam Goto) ([slides](https://gitpitch.com/samuelgoto/proposal-block-params))
     1. 60 Minute Items
-        1. [Class fields ASI](https://github.com/tc39/proposal-class-fields/issues/7) discussion and resolution (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1bPzE6i_Bpm6FXgzfx9XFJNHGkVcM42lux-6bUNhxpl4/edit#slide=id.p))
         1. [Inheriting private static class elements](https://github.com/tc39/proposal-class-fields/issues/43) discussion and resolution (Kevin Gibbons and Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1wgus0BykoVk_qqCpr0TjgO0TV0Y4ql4d9iY212phzbY/edit#slide=id.p))
         1. IEEE 754-2008 64-bit Decimal for Stage 0 (Andrew Paprocki and Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1jPsw7EGsS6BW59_BDRu9o0o3UwSXQeUhi38QG55ZoPI/edit?pli=1#slide=id.p))
-        1. [Decorators](https://github.com/tc39/proposal-unified-class-features/) discussion towards Stage 3 (Daniel Ehrenberg)
         1. [Distinguishing literal strings](https://github.com/mikewest/tc39-proposal-literals) proposal for Stage 0 (Adam Klein and Mike West)
         1. [Object.freeze + Object.seal syntax](https://github.com/keithamus/object-freeze-seal-syntax) proposal for Stage 0 (Keith Cirkel)
+        1. [Class fields ASI](https://github.com/tc39/proposal-class-fields/issues/7) discussion and resolution (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1bPzE6i_Bpm6FXgzfx9XFJNHGkVcM42lux-6bUNhxpl4/edit#slide=id.p))
+        1. [Decorators](https://github.com/tc39/proposal-unified-class-features/) discussion towards Stage 3 (Daniel Ehrenberg)
 1. Non-timeboxed overflow from previous meeting
 1. Non-timeboxed agenda items
     1. Stage 0+ proposals looking to advance


### PR DESCRIPTION
I'm presenting many topics. To encourage others to present and not hog all the time, this puts the timeboxed items where I was going to present at the bottom of their sections. Does such a change seem OK?

Addresses #271