### PR TITLE
Add 30 minute time slot to discuss Top Level Await

### DIFF
--- a/2018/01.md
+++ b/2018/01.md
@@ -108,6 +108,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. [`throw` expressions](https://github.com/tc39/proposal-throw-expressions) for stage 3 (Ron Buckton)
         1. Decorators use cases (Diego Ferreiro Val, Yehuda Katz and Carido Patino)
         1. new [Set builtin methods](https://docs.google.com/presentation/d/e/2PACX-1vR3U78vWdnSujZoGKR1EZOvhrIDJMcypwq3T0FY4bz-lG8LncSD_x89N2eS8anu5adviz1mhSrnf9lG/pub?start=false&loop=false&delayms=3000) for stage 2 (Sathya Gunasekaran, Michal Wadas)
+        1. Top Level Await for stage 0 (Myles Borins)
     1. 45 Minute Items
     1. 60 Minute Items
         1. [BigInt](https://github.com/tc39/proposal-bigint) status update ([significant recent change](https://github.com/tc39/proposal-bigint/pull/106)) (Daniel Ehrenberg)


### PR DESCRIPTION
I'd like to have a 30 minute time box discussion about bringing `Top Level Await` to stage 0.

I've had a combination of vacation + illness get in the way of me getting any presentation material together yet, but am confident I can have something together in time for the meeting. Please let me know if that is acceptable. If not we can push until March