### PR TITLE
Move null array spreadable to before object spread

### DIFF
--- a/2018/01.md
+++ b/2018/01.md
@@ -102,6 +102,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. [`Function.prototype.toString`](https://github.com/tc39/Function-prototype-toString-revision) ([PR](https://github.com/tc39/ecma262/pull/697)) for stage 4 (Michael Ficarra)
         1. [`Symbol.prototype.description`](https://github.com/tc39/proposal-Symbol-description) for stage 2 (Michael Ficarra)
         1. [Maximally minimal mixins proposal](https://gist.github.com/justinfagnani/9502b5f46599f474a67a5fce2f7af910) (Justin Fagnani)
+        1. [PR: Making nullish values iterable, or at least array-spreadable](https://github.com/tc39/ecma262/pull/1069) (Mathias Bynens)
         1. [Rest/Spread properties](https://github.com/tc39/proposal-object-rest-spread) ([PR](https://github.com/tc39/ecma262/pull/1048)) for stage 4 (Sebastian Markbåge)
         1. [`Function.prototype.toString()` censorship](https://github.com/domenic/proposal-function-prototype-tostring-censorship/blob/master/README.md) for stage 1 (Domenic Denicola)
         1. [`throw` expressions](https://github.com/tc39/proposal-throw-expressions) for stage 3 (Ron Buckton)
@@ -110,7 +111,6 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. [Top-level `await`](https://github.com/MylesBorins/proposal-top-level-await) for stage 0 (Myles Borins)
         1. [Getting last item from Array](https://github.com/keithamus/proposal-array-last) for stage 2 (Keith Cirkel)
         1. [Optional Chaining](https://github.com/tc39/proposal-optional-chaining) update (Gabriel Isenberg)
-        1. [PR: Making nullish values iterable, or at least array-spreadable](https://github.com/tc39/ecma262/pull/1069) (Mathias Bynens)
         1. Intl proposals for Stage 3: [`Intl.ListFormat`](https://github.com/tc39-transfer/proposal-intl-list-format), [`Intl.RelativeTimeFormat`](https://github.com/tc39/proposal-intl-relative-time), [`Intl.Locale`](https://github.com/tc39/proposal-intl-locale) (Zibi Braniecki) [slides](https://docs.google.com/presentation/d/1JlVOkn21jyF4YlsxBeisfvyYKzf5AZYNUzrUeZD12CQ/edit#slide=id.g2e1d914bb7_0_62)
     1. 45-minute items
         1. Discussion of cache timing attack (Meltdown and Spectre being just the latest examples) consequences (Waldemar Horwat)


### PR DESCRIPTION
We should probably decide on this before moving object spread to stage 4, in case a change to that proposal falls out of it (although it might not be web compatible).