### PR TITLE
Add details of JS research meeting prior to March meeting

### DIFF
--- a/2018/03.md
+++ b/2018/03.md
@@ -37,6 +37,17 @@ Allen's paper on standards committee participation for new attendees: http://wir
 
 [Doodle](https://ecma-international.doodle.com/poll/eqp4epm84rxgny5b)
 
+### Formal Methods Meets JavaScript Meeting
+* Date: Monday 19 March 2018 (day before TC39 meeting)
+* Location: Imperial College London
+* Organisers: Prof. Philippa Gardner (Imperial College London, host of TC39 meeting), Alan Schmitt (Inria, France, TC39
+  member)
+
+Research talks on Programming Languages Formal Methods researchers on topics including language specification,
+program verification, etc. with a focus on research relating to the JavaScript language and ecosystem.
+
+Speakers and talk titles/abstracts TBC.
+
 ### Hotels
 
 The Imperial College accommodation service offer a free service to all visitors to make a booking at a


### PR DESCRIPTION
Imperial are hosting a "Formal Methods Meets JS" meeting the day prior to the March TC39 meeting (at the same venue), brief meeting description:
> Research talks on Programming Languages Formal Methods researchers on topics including language specification, program verification, etc. with a focus on research relating to the JavaScript language and ecosystem.

This PR adds this satellite event to the Logistics section of the agenda.