### PR TITLE
Add update on WASM ES modules to the agenda

### DIFF
--- a/2018/03.md
+++ b/2018/03.md
@@ -138,6 +138,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. Object.fromEntries for Stage 1 (Jordan Harband &amp; Kevin Gibbons) ([github](https://github.com/bathos/object-from-entries))
         1. Update on `Array.prototype.flatten` web incompatibility (Kevin Gibbons) ([github](https://github.com/tc39/proposal-flatMap/pull/56))
         1. Needs-consensus PR: [Fix `length` property of TypedArrays, DataView, and ArrayBuffer constructors](https://github.com/tc39/ecma262/pull/1131) (Leo Balter, PR by André Bargull)
+        1. Update on WASM ES modules (Lin Clark) ([slides](https://linclark.github.io/wasm-es-modules/slides/2018-03-06/#/0))
     1. 30-minute items
         1. Extended Numeric Literals (Daniel Ehrenberg) ([slides](https://docs.google.com/presentation/d/1fEhTnHGyIBIHBiImT6W0eYdBLLY0oRGyjAq6dItZgqE/edit#slide=id.p), [explainer](https://github.com/tc39/proposal-extended-numeric-literals/blob/master/README.md), [spec](https://tc39.github.io/proposal-extended-numeric-literals/))
         1. Richer Keys for stage 1 (Bradley Farias) ([slides](https://docs.google.com/presentation/d/1q3CGeXqskL1gHTATH_VE9Dhj0VGTIAOzJ1cR0dYqDBk/edit#slide=id.p))


### PR DESCRIPTION
This proposal was presented to the WASM CG on March 6 and has moved forward to Stage 0. It will require some small changes to the ES modules spec (to factor out cycle handling to a common base class), so I wanted to present in order to keep TC39 informed of the progress in the WASM CG. 