### PR TITLE
Add more presentation slide links

### DIFF
--- a/2018/03.md
+++ b/2018/03.md
@@ -130,7 +130,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. Richer Keys for stage 1 (Bradley Farias) ([slides](https://docs.google.com/presentation/d/1q3CGeXqskL1gHTATH_VE9Dhj0VGTIAOzJ1cR0dYqDBk/edit#slide=id.p))
         1. Hashbang Grammar for Stage 2 (Bradley Farias) ([github](https://github.com/bmeck/proposal-hashbang))
         1. Needs-consensus PR: [Array Buffer Detach layering improvement](https://github.com/tc39/ecma262/pull/1112)
-        1. BigInt status update (Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-bigint/), [spec](https://tc39.github.io/proposal-bigint/). [slides](https://docs.google.com/presentation/d/1kexAmEsKMi8Blkb_wUeHKyx-3iqKUjWoyaDBMQ168Bk/edit#slide=id.p))
+        1. BigInt status update (Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-bigint/), [spec](https://tc39.github.io/proposal-bigint/), [slides](https://docs.google.com/presentation/d/1kexAmEsKMi8Blkb_wUeHKyx-3iqKUjWoyaDBMQ168Bk/edit#slide=id.p))
         1. Slice notation for stage 1 (Sathya Gunasekaran) ([explainer](https://github.com/gsathya/proposal-slice-notation/))
         1. Nullish coalescing for stage 2 (Gabriel Isenberg) ([explainer](https://github.com/tc39/proposal-nullish-coalescing), [spec](https://tc39.github.io/proposal-nullish-coalescing/), [slides](https://docs.google.com/presentation/d/1vRiLFVYOXrKrqCxe-xEAkhAEaWXAdfZ0h8MPAIQ6mtc/edit?usp=sharing))
         1. Module fallback imports for stage 1 ([github](https://github.com/kmiller68/module-fallback-imports))
@@ -139,10 +139,10 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. Optional chaining for stage 2 (Gabriel Isenberg) ([explainer](https://github.com/tc39/proposal-optional-chaining), [spec](https://tc39.github.io/proposal-optional-chaining/), [slides](https://docs.google.com/presentation/d/1XDUB1gGRmD6cIUu2-bVXEA-ZrWUIfQfhWxFKALCAXOQ/edit?usp=sharing))
     1. 60-minute items
         1. Weak References for stage 2 (Dean Tribble) ([explainer](https://github.com/tc39/proposal-weakrefs/blob/master/specs/weakrefs.md),[slides](https://github.com/tc39/proposal-weakrefs/blob/master/specs/Weak%20References%20for%20EcmaScript.pdf))
-        1. Static public fields for Stage 3 (Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-static-class-features/), [spec](https://tc39.github.io/proposal-static-class-features/))
-        1. Decorators towards Stage 3 (Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-decorators/), [spec](https://tc39.github.io/proposal-decorators/))
-        1. Pipeline operators Stage 1 update (Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-pipeline-operator/), [spec](https://tc39.github.io/proposal-pipeline-operator/))
         1. JavaScript Classes 1.1 (Kevin Smith, Brendan Eich, Allen Wirfs-Brock) ([explainer](https://github.com/zenparsing/js-classes-1.1), [spec](https://zenparsing.github.io/js-classes-1.1/))
+        1. Static public fields for Stage 3 (Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-static-class-features/), [spec](https://tc39.github.io/proposal-static-class-features/))
+        1. Decorators towards Stage 3 (Brian Terlson, Yehuda Katz, Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-decorators/), [spec](https://tc39.github.io/proposal-decorators/), [slides](https://docs.google.com/presentation/d/1Sx5gwx9yd3gbRhbzgwQijGLRIbfR9PkwLlwfNK_USQs/edit#slide=id.p))
+        1. Pipeline operators Stage 1 update (J S Choi, James DiGioia, Daniel Ehrenberg) ([explainer](https://github.com/tc39/proposal-pipeline-operator/), [spec](https://tc39.github.io/proposal-pipeline-operator/), [presentation](https://docs.google.com/presentation/d/1eFFRK1wLIazIuK0F6fY974OIDvvWXS890XAMB59PUBA/edit#slide=id.p))
 1. Non-timeboxed overflow from previous meeting
     1. Followup to discussion from previous meetings: [identifying risk areas](https://github.com/tc39/process-document/pull/18) (Jordan Harband)
 1. Non-timeboxed agenda items


### PR DESCRIPTION
Also move JS classes 1.1 to go above my hour-long presentations, partially addressing https://github.com/tc39/agendas/issues/338 .