### PR TITLE
Add agenda item for recapping IP policy

### DIFF
--- a/2018/05.md
+++ b/2018/05.md
@@ -62,6 +62,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     1. Opening of the meeting (Mr. Jaeschke)
     1. Introduction of attendees
     1. Host facilities, local logistics
+    1. Quick recap of meeting IPR policy (Daniel Ehrenberg)
 1. Find volunteers for note taking
 1. Adoption of the agenda
 1. Approval of the minutes from last meeting


### PR DESCRIPTION
This would just be 15 seconds or so, to recap that, if you are not a delegate of an Ecma member organization, please either sign the [IP form](https://tc39.github.io/agreements/contributor/) for invited experts or remain a silent observer.

Better safe than sorry, or is this too much of a waste of time?