### PR TITLE
Add SuperProperty evaluation order presentation

### DIFF
--- a/2018/05.md
+++ b/2018/05.md
@@ -90,6 +90,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
         1. [Normative: Cleanup Time Values and Time Range](https://github.com/tc39/ecma262/pull/1144) Needs Consensus PR (Andrew Paprocki)
         1. [Normative: Add `export * as ns from "mod”` to Export production and Module Semantics](https://github.com/tc39/ecma262/pull/1174) (Valerie Young, John-David Dalton)
         1. Array.prototype.values web compat update (Sathya Gunasekaran)
+        1. :hourglass: SuperProperty evaluation order (Justin Ridgewell) ([issue](https://github.com/tc39/ecma262/issues/1175), [slides](https://docs.google.com/presentation/d/1hYEAK5-fO97tbnsJlsxypcx5YBPYm09-TPf00s3Ck5g/))
     1. 30-minute items
     1. 45-minute items
     1. 60-minute items


### PR DESCRIPTION
This is super late, so I'm not sure if it should be accepted.

If it is, it should be the lowest priority item. Maybe a time-filler if we can't get all the longer presentations items in?

And if it's not accepted, I'll do better getting it onto the next meeting's agenda on time.