### PR TITLE
Add Unified Intl.NumberFormat agenda item for stage 2

### DIFF
--- a/2018/07.md
+++ b/2018/07.md
@@ -91,6 +91,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | stage | timebox | topic | presenter |
     |:-----:|:-------:|-------|-----------|
+    | 0     | 45m     | [`Intl.NumberFormat` Unified Feature Proposal](https://github.com/sffc/proposal-unified-intl-numberformat) for Stage 2 | Shane Carr |
     | 2     | 60m     | Decorators for Stage 3 | Daniel Ehrenberg |
     | 1     | 60m     | Temporal for Stage 2 | Maggie Pint |
 


### PR DESCRIPTION
I called into the May TC39 meeting and gave a brief overview of this proposal for Stage 0.  We are ready to advance it to Stage 2 in the July TC39 meeting in Redmond.

The summary of the proposal is here: https://github.com/sffc/proposal-unified-intl-numberformat

Please let me know if this is the correct way to add this to the agenda.

@littledan @fabalbon 