### PR TITLE
Reorder discussion topics, add lightning talks

### DIFF
--- a/2018/07.md
+++ b/2018/07.md
@@ -72,7 +72,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
 
-1. Timeboxed overflow from previous meeting
+1. Overflow from previous meeting
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
@@ -91,18 +91,28 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | stage | timebox | topic | presenter |
     |:-----:|:-------:|-------|-----------|
     | 3     | 15m     | New name for [`global`](https://github.com/tc39/proposal-global/issues/20) | Jordan Harband |
-    | 0     | 45m     | [`Intl.NumberFormat` Unified Feature Proposal](https://github.com/sffc/proposal-unified-intl-numberformat) for Stage 2 | Shane Carr |
     | 2     | 60m     | Decorators for Stage 3 | Daniel Ehrenberg |
     | 1     | 60m     | Temporal for Stage 2 | Maggie Pint |
+
+1. Stage 0 10m lightning talks (Thursday morning)
+
+    | topic | presenter |
+    |-------|-----------|
 
 1. Longer or open-ended discussions (Thursday afternoon)
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
-    | 30m     | Open-ended discussion: How should we analyze complexity and cross-cutting concerns on syntax and library proposals? | Daniel Ehrenberg |
-    | 30m     | Open-ended discussion: How should we collaborate within a large committee? | Daniel Ehrenberg |
-    | 45m     | Reviewing the future JS syntax throughout the current proposals ([slides]()) | Leo Balter |
+    | 30m     | Open-ended discussion: How should we analyze complexity and cross-cutting concerns on syntax and library proposals? (overflow) | Daniel Ehrenberg |
+    | 30m     | Open-ended discussion: How should we collaborate within a large committee?  (overflow) | Daniel Ehrenberg |
+    | 45m     | Reviewing the future JS syntax throughout the current proposals ([slides]()) (overflow) | Leo Balter |
     | 60m     | [Abstractions for membranes](https://github.com/ajvincent/es-membrane) | Alex Vincent (expert invited by Mark S. Miller) |
+    
+1. 15m+ Stage 0 proposals
+
+    | timebox | topic | presenter |
+    |:-------:|-------|-----------|
+    | 45m     | [`Intl.NumberFormat` Unified Feature Proposal](https://github.com/sffc/proposal-unified-intl-numberformat) for Stage 2 | Shane Carr |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
Reordering per https://github.com/tc39/agendas/issues/397#issuecomment-398423845
- Add a "Stage 0 lightning talks" section, 10 minutes per topic
- Put discussion topics after Stage 0 lightning talks, and remaining new Stage 0 proposals after that
- Maintain the placement of overflow items at the front; we can consider changes to handle overflow buildup in a follow-on PR

Let's make sure to get feedback from the people who voiced opinions on #397 before merging. cc @leobalter @ljharb @michaelficarra @domenic