### PR TITLE
Add Schedule constraint

### DIFF
--- a/2018/07.md
+++ b/2018/07.md
@@ -139,6 +139,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 * Thomas Wood (for "Call for volunteers on TC39 technical infrastructure" item) can only dial in for morning/early
   afternoon (until ~14:00) sessions.
 * Yulia Startsev can only attend in the mornings. (for website update)
+* Maya Lekova (for "Normative: Reduce the number of ticks in async/await" item) can only dial in for morning/early
+  afternoon (until ~14:00) sessions, preferably on Wednesday.
 
 ## Dates and locations of future meetings
 


### PR DESCRIPTION
I'd be happy to dial in for the topic "Normative: Reduce the number of ticks in async/await", so adding my CET-related timing constraints.