### PR TITLE
remove placeholder slides link

### DIFF
--- a/2018/07.md
+++ b/2018/07.md
@@ -116,7 +116,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
     | 30m     | Groups! For in-depth discussions and community feedback (overflow) ([slides](https://docs.google.com/presentation/d/1x2t8ggcpFlZ2zl1RjVgO5fmGjqXRxlkoqcGDKY5ksVg/edit#slide=id.p), [Reflector post](https://github.com/tc39/Reflector/issues/158)) (overflow) | Yulia Startsev |
-    | 45m     | Reviewing the future JS syntax throughout the current proposals ([slides]()) (overflow) | Leo Balter |
+    | 45m     | Reviewing the future JS syntax throughout the current proposals (overflow) | Leo Balter |
     | 60m     | [Abstractions for membranes](https://github.com/ajvincent/es-membrane) | Alex Vincent (expert invited by Mark S. Miller) |
     | 30m     | Some web stuff I've been working on that Dan thinks we should talk about | Domenic Denicola |
     | 30m     | User testing (e.g. usability or learnability): call for resources | Shu-yu Guo |


### PR DESCRIPTION
/cc @leobalter maybe we could get the actual slides link instead