### PR TITLE
Remove day/time suggestions

### DIFF
--- a/2018/07.md
+++ b/2018/07.md
@@ -106,12 +106,12 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | 1     | 45m     | [Partial Application](https://github.com/tc39/proposal-partial-application) Update ([slides](https://docs.google.com/presentation/d/1XBZOJFHuy8Ig9hdUiqKfVleAHMVYs_8KT5G4bwGh0XM/edit?usp=sharing)) | Ron Buckton |
     | 1     | 30m     | [Cancellation](https://github.com/tc39/proposal-cancellation) Update ([slides](https://docs.google.com/presentation/d/19M7OkW8fr-HBYzgQRDSX77Pn4WmGh_5gPnBV38N3x08/edit?usp=sharing)) | Ron Buckton |
 
-1. Stage 0 10m lightning talks (Thursday morning)
+1. Stage 0 10m lightning talks
 
     | topic | presenter |
     |-------|-----------|
 
-1. Longer or open-ended discussions (Thursday afternoon)
+1. Longer or open-ended discussions
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|


### PR DESCRIPTION
Thursday morning/afternoon for certain topics seems unrealistic; let's work out the details later.