### PR TITLE
2018.09: add Ecma fellows nominations

### DIFF
--- a/2018/09.md
+++ b/2018/09.md
@@ -100,6 +100,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     1. Test262 Status Updates (15m)
 1. Updates from the CoC Committee (15m)
 1. Ad-hoc TC39 History Group - Archival data and you! (<10 mins, Jory Burson)
+1. Ecma Fellows nominations (5m)
 1. [Web compatibility issues](https://github.com/tc39/ecma262/issues?utf8=✓&q=is%3Aopen+label%3A%22web+reality%22+is%3Aissue) / [Needs Consensus PRs](https://github.com/tc39/ecma262/pulls?q=is%3Apr+is%3Aopen+label%3A%22needs+consensus%22)
 
     | timebox | topic | presenter |


### PR DESCRIPTION
Sorry for missing the deadline, but Ecma Fellows nominations need to be in by the end of this meeting, and we discussed the plan for this topic in the previous TC39 meeting.