### PR TITLE
WebAssembly modules update

### DIFF
--- a/2018/11.md
+++ b/2018/11.md
@@ -89,6 +89,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
+    | 10m     | Modules layering/naming change to support WebAssembly modules ([PR #1311](https://github.com/tc39/ecma262/pull/1311), [PR #1312](https://github.com/tc39/ecma262/pull/1312)) | Daniel Ehrenberg (author: Lin Clark) |
 
 
 1. Overflow from previous meeting


### PR DESCRIPTION
Should this be handled all on GitHub instead? Editors, if you decide to land this patch before the meeting, no need to discuss there.