### PR TITLE
agenda: built in specifiers

### DIFF
--- a/2019/01.md
+++ b/2019/01.md
@@ -120,7 +120,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | 30m | TC39 rationale - a proposed starting point ([slides](https://docs.google.com/presentation/d/1c4RY8ld-um7gsfoosoHNXQER6qZoUu6mLxiCwOjkhK0/edit#slide=id.p)) | Yulia Startsev |
     | 15m | Overloading method parameters between BigInt and Number: Just Say No (?) ([slides](https://docs.google.com/presentation/d/11A3MSCUv9XEkquWPaCl3GkksI4v5bhZOMSe5r5Aj_uw/edit#slide=id.p)) | Daniel Ehrenberg |
     | 15m | [Simplifying `Set` constructor](https://github.com/tc39/ecma262/issues/1430) | Kevin Gibbons |
-
+    | 30m | [Module specifier for builtins](https://github.com/tc39/proposal-javascript-standard-library/issues/12) | Myles Borins |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
I was planning to bring this up during discussion around
"Standard Library" which appears to have been removed from the agenda.
Is it too late to add this? Requesting 30 minutes but would settle for
even 5 minutes

Refs: https://github.com/tc39/proposal-javascript-standard-library/issues/12
Refs: https://github.com/nodejs/node/pull/21551