### PR TITLE
add schedule constraints for Angular

### DIFF
--- a/2019/03.md
+++ b/2019/03.md
@@ -127,6 +127,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 ### Schedule constraints
 
 - Domenic will not be present on day 1, so his item should be scheduled on the other days
+- Angular representatives (@IgorMinar, @mhevery, @mgechev) would like to dial in and participate in the "(Yet another) [decorators](https://github.com/tc39/proposal-decorators/) Stage 2 update" discussion. If possible, they request that the discussion occurs on Wed, March 27 within one of the following slots: 1:30-3pm EDT and less preferably 4-5pm EDT.
 
 ## Dates and locations of future meetings
 


### PR DESCRIPTION
Angular would like to attend remotely for the decorators discussion, but due to various other events we have very limited availability during this TC39 meeting.

// fyi: @littledan