### PR TITLE
Add JavaScript Commons namespace

### DIFF
--- a/2019/06.md
+++ b/2019/06.md
@@ -112,6 +112,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | | 45m     | Evidence-based Programming Language Design | Felienne Hermans |
     | | 45m     | JavaScript and Syntax Research Methods | Yulia Startsev |
     | | 30m     | Status update on non-JS module types (e.g., JSON, CSS, WebIDL) | Daniel Ehrenberg |
+    | | 30m     | JavaScript Commons namespace | Anne van Kesteren |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
To present an idea of how a shared namespace between the various usage scenarios of JavaScript could be managed.