### PR TITLE
Fix item ordering

### DIFF
--- a/2019/10.md
+++ b/2019/10.md
@@ -94,8 +94,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   3   |   15m   | Update on [Optional Chaining](https://github.com/tc39/proposal-optional-chaining/) and [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing/) ([slides](https://1drv.ms/p/s!AltPy8G9ZDJdqUDKxXPEzDwlcv3H)) | Daniel Rosenwasser |
     |   3   |   15m   | Update on [Top-level await](https://github.com/tc39/proposal-top-level-await), including [layering for ServiceWorker](https://github.com/tc39/proposal-top-level-await/pull/128) | Myles Borins |
     |   3   |   15m   | [globalThis](https://github.com/tc39/proposal-global) for [stage 4](https://github.com/tc39/proposal-global/issues/12) | Jordan Harband |
-    |   3   |   30m   | Update on [Class Fields](https://github.com/tc39/proposal-class-fields), [Private methods](https://github.com/tc39/proposal-private-methods), and [Static class features](https://github.com/tc39/proposal-static-class-features) | Caio Lima |
     |   3   |   15m   | Update on [RegExp Match Indices](https://github.com/tc39/proposal-regexp-match-indices) | Ron Buckton |
+    |   3   |   30m   | Update on [Class Fields](https://github.com/tc39/proposal-class-fields), [Private methods](https://github.com/tc39/proposal-private-methods), and [Static class features](https://github.com/tc39/proposal-static-class-features) | Caio Lima |
     |   2   |   15m   | [`Promise.any`](https://github.com/tc39/proposal-promise-any/) for Stage 3 ([slides](https://docs.google.com/presentation/d/1mHpRSi1xFJEwuLwN31kRLPBQIpd27EdlAbG4yNakbD0/edit)) | Mathias Bynens |
     |   2   |   30m   | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replace-all) for Stage 3 ([slides](https://docs.google.com/presentation/d/1OGmV6uVTOEeSYO1nMeLjzflkbRJZ4p9QXlGV8IvDMmU/edit)) | Mathias Bynens |
     |   2   |   30m   | Update on [Temporal](https://github.com/tc39/proposal-temporal) | Philipp Dunkel |
@@ -104,13 +104,13 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   2   |   30m   | [Intl.DisplayNames](https://github.com/tc39/proposal-intl-displaynames) for Stage 3 ([slides](http://shorturl.at/yPSZ1)) | Frank Tang |
     |   1   |   30m | [Map#upsert , previously Map#insertOrUpdate for Stage 2](https://github.com/thumbsupep/proposal-upsert) | Erica Pramer |
     |   0   |   30m   | `Object.map` for Stage 1 ([slides](https://1drv.ms/p/s!As13Waij_jkUqeV6IHXsJBMDkNIgXw)) | Jonathan Keslin |
-    |   0   |   60m   | [Const Value Types](https://github.com/rricard/proposal-const-value-types) for Stage 1 (slides forthcoming) | Robin Ricard, Richard Button |
     |   0   |   30m   | [Declarations in Conditionals](https://github.com/dcrousso/JS-Declarations-in-Conditionals) for Stage 1 | Devin Rousso |
     |   0   |   30m   | [UUID](https://github.com/bcoe/proposal-standard-library-uuid) for Stage 1 | Ben Coe |
     |   0   |   30m   | [OOM Fails Fast](https://github.com/Agoric/proposal-oom-fails-fast) for Stage 1 | Mark S. Miller |
     |   0   |   30m   | [Support for Distributed Promise Pipelining](https://github.com/Agoric/proposal-eventual-send) for stage 1 | Mark S. Miller |
     |   0   |   30m   | [Wavy Dot syntax for promise pipelining](https://github.com/Agoric/proposal-wavy-dot) for stage 1 | Mark S. Miller |
     |   0   |   30m   | [Readonly Collections](https://github.com/Agoric/proposal-readonly-collections) for stage 1 | Mark S. Miller |
+    |   0   |   60m   | [Const Value Types](https://github.com/rricard/proposal-const-value-types) for Stage 1 (slides forthcoming) | Robin Ricard, Richard Button |
 
 
 1. Longer or open-ended discussions


### PR DESCRIPTION
Sorting by timebox per requirement:
> Proposal-based agenda items should be sorted primarily by stage (descending), secondarily by timebox (ascending), and finally by insertion date.