### PR TITLE
replace records and tuples slides link with permanent version

### DIFF
--- a/2019/10.md
+++ b/2019/10.md
@@ -109,7 +109,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   0   |   30m   | [Support for Distributed Promise Pipelining](https://github.com/Agoric/proposal-eventual-send) for stage 1 | Mark S. Miller |
     |   0   |   30m   | [Wavy Dot syntax for promise pipelining](https://github.com/Agoric/proposal-wavy-dot) for stage 1 | Mark S. Miller |
     |   0   |   30m   | [Readonly Collections](https://github.com/Agoric/proposal-readonly-collections) for stage 1 | Mark S. Miller |
-    |   0   |   60m   | [Records & Tuples](https://github.com/rricard/proposal-const-value-types) for Stage 1 (([slides](https://bit.ly/2oRdIv8)) | Robin Ricard, Richard Button |
+    |   0   |   60m   | [Records & Tuples](https://github.com/rricard/proposal-const-value-types) for Stage 1 ([slides](https://button.dev/talks/records-and-tuples-tc39-october-2019.pdf)) | Robin Ricard, Richard Button |
 
 
 1. Longer or open-ended discussions


### PR DESCRIPTION
The new link contains exactly the same slide deck bit-for-bit, but I've hosted it in a permanent location instead of a temporary dropbox.