### PR TITLE
Add links to projects and CoC Committee

### DIFF
--- a/2019/12.md
+++ b/2019/12.md
@@ -59,11 +59,11 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 1. Next meeting host and logistics
 1. Report from the Ecma Secretariat (15m, Istvan Sebestyen)
 1. Project Editors’ Reports
-    1. ECMA262 Status Updates (15m)
+    1. [ECMA262](https://github.com/tc39/ecma262) Status Updates (15m)
     1. [ECMA402](https://github.com/tc39/ecma402) Status Updates (15m)
-    1. ECMA404 Status Updates (15m)
-    1. Test262 Status Updates (15m)
-1. Updates from the CoC Committee (15m)
+    1. [ECMA404](https://www.ecma-international.org/publications/standards/Ecma-404.htm) Status Updates (15m)
+    1. [Test262](https://github.com/tc39/test262) Status Updates (15m)
+1. Updates from the [CoC Committee](https://tc39.es/code-of-conduct/#code-of-conduct-committee) (15m)
 1. [Web compatibility issues](https://github.com/tc39/ecma262/issues?utf8=✓&q=is%3Aopen+label%3A%22web+reality%22+is%3Aissue) / [Needs Consensus PRs](https://github.com/tc39/ecma262/pulls?q=is%3Apr+is%3Aopen+label%3A%22needs+consensus%22)
 
     | ✓ | timebox | topic | presenter |

--- a/template.md
+++ b/template.md
@@ -63,11 +63,11 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 1. Next meeting host and logistics
 1. Report from the Ecma Secretariat (15m, Istvan Sebestyen)
 1. Project Editors’ Reports
-    1. ECMA262 Status Updates (15m)
+    1. [ECMA262](https://github.com/tc39/ecma262) Status Updates (15m)
     1. [ECMA402](https://github.com/tc39/ecma402) Status Updates (15m)
-    1. ECMA404 Status Updates (15m)
-    1. Test262 Status Updates (15m)
-1. Updates from the CoC Committee (15m)
+    1. [ECMA404](https://www.ecma-international.org/publications/standards/Ecma-404.htm) Status Updates (15m)
+    1. [Test262](https://github.com/tc39/test262) Status Updates (15m)
+1. Updates from the [CoC Committee](https://tc39.es/code-of-conduct/#code-of-conduct-committee) (15m)
 1. [Web compatibility issues](https://github.com/tc39/ecma262/issues?utf8=✓&q=is%3Aopen+label%3A%22web+reality%22+is%3Aissue) / [Needs Consensus PRs](https://github.com/tc39/ecma262/pulls?q=is%3Apr+is%3Aopen+label%3A%22needs+consensus%22)
 
     | ✓ | timebox | topic | presenter |


### PR DESCRIPTION
ECMA402 already had a link. This adds links to the rest.

I'm not sure if this is the correct link for ECMA404. It's the best I
could find. Feel free to edit this PR before merging.