### PR TITLE
Sort stage 2 proposals by timebox and insertion order

### DIFF
--- a/2019/12.md
+++ b/2019/12.md
@@ -81,16 +81,16 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | stage | timebox | topic | presenter |
     |:-:|:-----:|:-------:|-------|-----------|
-    |   | 3     | 45m     | [Optional Chaining](https://github.com/tc39/proposal-optional-chaining/) for Stage 4 | Daniel Rosenwasser |
-    |   | 3     | 45m     | [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing/) for Stage 4 | Daniel Rosenwasser |
     |   | 3     | 15m     | [Intl.Locale for stage 4](https://github.com/tc39/proposal-intl-locale/) | Zibi Braniecki, Caio Lima
     |   | 3     | 15m     | [Intl.RelativeTimeFormat for stage 4](https://github.com/tc39/proposal-intl-relative-time) | Zibi Braniecki, Caio Lima
     |   | 3     | 15m     | [Intl.NumberFormat rev. 2 for stage 4](https://github.com/tc39/proposal-unified-intl-numberformat) | Shane Carr
     |   | 3     | 15m     | [import.meta for stage 4](https://github.com/tc39/proposal-import-meta/) | Myles Borins
+    |   | 3     | 45m     | [Optional Chaining](https://github.com/tc39/proposal-optional-chaining/) for Stage 4 | Daniel Rosenwasser |
+    |   | 3     | 45m     | [Nullish Coalescing](https://github.com/tc39/proposal-nullish-coalescing/) for Stage 4 | Daniel Rosenwasser |
     |   | 2     | 30m     | [`Atomics.waitAsync`](https://github.com/tc39/proposal-atomics-wait-async) for Stage 3 | Shu-yu Guo |
+    |   | 2     | 30m     | [updates on realms](https://github.com/tc39/proposal-realms) | Caridy Patiño |
     |   | 2     | 45m     | [function implementation hiding](https://github.com/tc39/proposal-function-implementation-hiding) for stage 3 | Michael Ficarra |
     |   | 2     | 60m     | [iterator helpers](https://github.com/tc39/proposal-iterator-helpers) for stage 3 | Michael Ficarra |
-    |   | 2     | 30m     | [updates on realms](https://github.com/tc39/proposal-realms) | Caridy Patiño |
     |   | 1     | 15m     | [Update on UUID](https://github.com/tc39/proposal-uuid) | Benjamin Coe |
     |   | 0     | 15m     | [Array select/reject](https://github.com/jridgewell/proposal-array-select-reject) for stage 1 | Justin Ridgewell |
     |   | 0     | 30m     | [Async initialization](https://docs.google.com/presentation/d/1DsjZAzBjn2gCrr4l0uZzCymPIWZTKM8KzcnMBF31HAg/edit?usp=sharing) for stage 1 | Bradley Farias |


### PR DESCRIPTION
According to [agenda topic rules](https://github.com/tc39/agendas/blob/master/2019/12.md#agenda-topic-rules)

> 4. Proposal-based agenda items should be sorted primarily by stage (descending), secondarily by timebox (ascending), and finally by insertion date.