### PR TITLE
split out cleanupSome proposal

### DIFF
--- a/2020/06.md
+++ b/2020/06.md
@@ -79,6 +79,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 3     | 15m     | [`String.prototype.replaceAll`](https://github.com/tc39/proposal-string-replace-all) for Stage 4 (slides TBD) | Mathias Bynens |
     |   | 3     | 15m     | Logical Assignment ([Status Update][lgcl-assign], [NamedEvaluation][lgcl-namedevaluation]) | Justin Ridgewell |
     |   | 3     | 15m     | Changing Promise.any's AggregateError's argument processing order ([PR](https://github.com/tc39/proposal-promise-any/pull/59)) | Shu-yu Guo |
+    |   | 3     | 15m     | Split out CleanupSome from Weakrefs proposal - Slides (WIP) | Yulia
+    Startsev |
     |   | 2     | 60m     | [Function Implementation Hiding](https://github.com/tc39/proposal-function-implementation-hiding) for stage 3 ([slides](https://docs.google.com/presentation/d/1zCACnOkueOZHruXv2UzUvKIUA6L7w7W6S2N4bdzwwkM/edit)) ([spec text](https://github.com/tc39/ecma262/pull/1739)) | Michael Ficarra |
     |   | 2     | 60m     | [Realms, Stage 2 updates](https://github.com/tc39/proposal-realms) (slides TBD) | Caridy Patiño, Leo Balter |
     |   | 1     | 30m     | [Ergonomic brand checks for private fields][private-fields-in-in] for stage 2 | Jordan Harband |


### PR DESCRIPTION
Not sure this is the right place for the discussion, but I want to propose splitting cleanupSome from the weakrefs proposal to its own stage 3 proposal, so that we do not get blocked with weakrefs. 