### PR TITLE
Clarify meeting timezone as Chicago time (UTC-5)

### DIFF
--- a/2020/06.md
+++ b/2020/06.md
@@ -6,11 +6,11 @@
 - **Host**: Paypal
 - **Dates**: June 1 - 4, 2020
 - **Times**:
-  - 10:00 to 15:00 CT on June 1st, 2020
-  - 10:00 to 15:00 CT on June 2nd, 2020
-  - 10:00 to 15:00 CT on June 3rd, 2020
-  - 10:00 to 15:00 CT on June 4th, 2020
-- **Location**: Remote
+  - 10:00 to 15:00 CDT (UTC -5) on June 1st, 2020
+  - 10:00 to 15:00 CDT (UTC -5) on June 2nd, 2020
+  - 10:00 to 15:00 CDT (UTC -5) on June 3rd, 2020
+  - 10:00 to 15:00 CDT (UTC -5) on June 4th, 2020
+- **Location**: Remote (was Chicago)
 - **Attendee information**: https://github.com/tc39/Reflector/issues/279
 
 Allen's paper on standards committee participation for new attendees: http://wirfs-brock.com/allen/files/papers/standpats-asianplop2016.pdf


### PR DESCRIPTION
Fixes #782 

This meeting was due to be held in the Chicago Paypal office but it is now remote.