### PR TITLE
Add a recurring agenda slot for incubation call

### DIFF
--- a/2020/06.md
+++ b/2020/06.md
@@ -63,6 +63,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
+    
+1. Incubation call chartering (15m on the last day)
 
 1. Short (&le;30m) Timeboxed Discussions
 

--- a/template.md
+++ b/template.md
@@ -61,6 +61,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
 
+1. Incubation call chartering (15m on the last day)
+
 1. Short (&le;30m) Timeboxed Discussions
 
     | ✓ | timebox | topic | presenter |


### PR DESCRIPTION
Incubation calls will be re-chartered at the end of every plenary to identify the set of proposals that'll participate in the calls in between plenary meetings.