### PR TITLE
Meta Discussion: Flex Incubator Calls to weekly meetings

### DIFF
--- a/2020/07.md
+++ b/2020/07.md
@@ -82,7 +82,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
-    |   | 15m     | Flex Incubator Calls to weekly meetings | Leo Balter |
+    |   | 15m     | [Flex Incubator Calls to weekly meetings](https://github.com/tc39/Reflector/issues/300) | Leo Balter |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 

--- a/2020/07.md
+++ b/2020/07.md
@@ -82,6 +82,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
+    |   | 15m     | Flex Incubator Calls to weekly meetings | Leo Balter |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
I'd like to propose us to flex the incubator calls to weekly meetings if we have enough topics.

Currently the incubator calls happens every other week. From my experience they are rich and help solving specific challenges for proposal before they are presented to the TC39 plenaries in a more organized fashion.

I'd like to encourage us to flex the frequency of incubator calls if we foresee enough content. If the demand is low, we can always fallback to every other week between each TC39 meeting.