### PR TITLE
Add normative PR to next agenda.

### DIFF
--- a/2020/07.md
+++ b/2020/07.md
@@ -56,6 +56,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
     |   | 10m     | retroactive consensus on Unicode 13 property names and aliases ([#1896](https://github.com/tc39/ecma262/pull/1896#issuecomment-642301441), [#1939](https://github.com/tc39/ecma262/pull/1939)) | Michael Ficarra |
+    |   | 15m     | Specify \8 and \9 in sloppy (non-template) strings ([#2054](https://github.com/tc39/ecma262/pull/2054)) | Ross Kirsling |
 
 1. Overflow from previous meeting
 


### PR DESCRIPTION
Adding agenda item for https://github.com/tc39/ecma262/pull/2054.