### PR TITLE
Number/BigInt.range for Stage 2

### DIFF
--- a/2020/07.md
+++ b/2020/07.md
@@ -86,6 +86,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 |     |   3   |   15m   | [Logical Assignment](https://github.com/tc39/proposal-logical-assignment/) for Stage 4 | Justin Ridgewell |
 |     |   2   |   15m   | [Ergonomic brand checks for private fields][private-fields-in-in] for stage 3 | Jordan Harband |
 |     |   1   |   15m   | [Symbol as WeakMap key](https://github.com/tc39/proposal-symbols-as-weakmap-keys) for Stage 2 ([spec](https://arai-a.github.io/ecma262-compare/?pr=2038)) | Daniel Ehrenberg |
+|     |   0   |   15m   | [Number.range](https://github.com/Jack-Works/proposal-Number.range) for Stage 2 ([spec](http://tc39.es/proposal-Number.range/)) | Jack Works |
 |     |   0   |   15m   | [await operations](https://github.com/Jack-Works/proposal-await.ops) for Stage 1 ([spec](https://jack-works.github.io/proposal-await.ops/)) | Jack Works |
 |     |   0   |   15m   | [Array.prototype.unique() proposal](https://github.com/TechQuery/array-unique-proposal) for Stage 1 | [@TechQuery](https://github.com/TechQuery) (presented by Jack Works) |
 


### PR DESCRIPTION
## `method` vs the first-class type (https://github.com/tc39/proposal-Number.range/issues/22):

I'm preferring the current method semantics to a first-class type (`Range` class).
The method semantics is much JS style and provides a much clear API.
If @rbuckton is strongly requiring the first-class type please leave a comment.

## reusable semantics (https://github.com/tc39/proposal-Number.range/issues/17):

In the [April meeting](https://github.com/tc39/notes/blob/master/meetings/2020-03/april-1.md#numberrange-and-bigintrange-for-stage-1) there are two kinds of ideas `iterator + non-reusable` / `first-class + reusable`, I choose the prior one. In the after discussions in https://github.com/tc39/proposal-Number.range/issues/17, I think non-reusable is a very natural idea for an iterator so I leave it as-is.

If @sffc and @littledan gonna block this due to the non-reusable semantics, please leave a comment.

----------------------------------------------

If there are no blocking reasons, I think it has met the stage 2 entrance criteria.