### PR TITLE
Add topic for NSL follow up

### DIFF
--- a/2020/07.md
+++ b/2020/07.md
@@ -100,6 +100,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 |     |   0   |   15m   | [Array.prototype.unique() proposal](https://github.com/TechQuery/array-unique-proposal) for Stage 1 ([slides](https://docs.google.com/presentation/d/116FDDK2klJoEL8s2Q7UXiDApC681N-Q9SwpC0toAzTU/edit#slide=id.g89f56b0333_1_150)) | [@TechQuery](https://github.com/TechQuery) (presented by Jack Works) |
 |     |   0   |   45m   | [ResizableArrayBuffer and GrowableSharedArrayBuffer](https://github.com/syg/proposal-resizablearraybuffer) for Stage 1 (slides forthcoming) | Shu-yu Guo |
 |     |   0   |   45m   | [Async Context](https://github.com/legendecas/proposal-async-context) updates & for Stage 1 (slides forthcoming) | Chengzhong Wu |
+|     |   0   |   15m   | Forbid Numeric [Separators in NonOctalDecimalIntegerLiteral fractional / exponent parts](https://github.com/tc39/proposal-numeric-separator/issues/49) | Leo Balter, Ross Kirsling |
 
 1. Longer or open-ended discussions
 


### PR DESCRIPTION
Ref https://github.com/tc39/proposal-numeric-separator/issues/49

I'm not gonna be able to prepare a slide or minor repo today, but I'd like to consult the desired direction from TC39. Also, it can become a small direct "PR w/ tests" package.

Short story: JSC, SpiderMonkey, and V8 and shipping w/ support for numeric separators in the exponential/fractional parts of NonOctalDecimalIntegerLiteral Literals. This conforms the current spec text of the Stage 3 NSL.

I believe this is a minor issue and I'm not sure we want to invest time to forbid this very specific case. I'm available to support a change if required, and I hope I can do it as a follow up of NSL, as we are asking Stage 4 for it in this same meeting. 

