### PR TITLE
Move operator overloading to the end

### DIFF
--- a/2020/07.md
+++ b/2020/07.md
@@ -68,7 +68,6 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
-    |   | 30m     | [Operator overloading](https://github.com/tc39/proposal-operator-overloading): a good direction for JS? | Daniel Ehrenberg |
     |   | 45m     | [Cognitive Dimensions of Notation](https://docs.google.com/presentation/d/1OpKfS5UYgcwmBuejoSOBpbgsYXXzO0gG7GJHo65UXPE/edit#slide=id.p): a framework for reflecting on language design | Yulia Startsev and Felienne Hermans |
 
 1. Incubation call chartering (15m on the last day)
@@ -119,6 +118,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 30m     | Documenting Invariants, ([repo](https://github.com/codehag/documenting-invariants), [slides](https://docs.google.com/presentation/d/1a9-E87grtSbFGTHMfEJJoVjbHbSTe2PH_ed8StssZ_w/edit#slide=id.p)) | Yulia Startsev |
     |   | 30m     | Many specific invariants to consider | Mark S. Miller |
     |   | 45m     | [Examining structural racism in TC39](https://github.com/tc39/Reflector/issues/305) | Dave Poole |
+    |   | 30m     | [Operator overloading](https://github.com/tc39/proposal-operator-overloading): a good direction for JS? | Daniel Ehrenberg |
+
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
Given so many important agenda items, I'd like this discussion topic to be deprioritized, and discussed only if there's time after other items (even though it's overflow from last meeting).