### PR TITLE
Clarify Hungary timezone

### DIFF
--- a/2020/11.md
+++ b/2020/11.md
@@ -5,10 +5,10 @@
 
 - **Host**: IBM
 - **Dates and times**:
-  - 10:00 to 15:00 CEST (UTC +2) on November 16th, 2020
-  - 10:00 to 15:00 CEST (UTC +2) on November 17th, 2020
-  - 10:00 to 15:00 CEST (UTC +2) on November 18th, 2020
-  - 10:00 to 15:00 CEST (UTC +2) on November 19th, 2020
+  - 10:00 to 15:00 CET (UTC +1) on November 16th, 2020
+  - 10:00 to 15:00 CET (UTC +1) on November 17th, 2020
+  - 10:00 to 15:00 CET (UTC +1) on November 18th, 2020
+  - 10:00 to 15:00 CET (UTC +1) on November 19th, 2020
 - **Location**: Remote (was Budapest)
 - **Attendee information**: LINK TO REFLECTOR
 
@@ -16,7 +16,7 @@ Allen's paper on standards committee participation for new attendees: http://wir
 
 ## Agenda topic rules
 
-Deadline for advancement eligibility: [**November 6th, 2020, 10:00 CEST**](https://www.timeanddate.com/countdown/generic?p0=1440&iso=20201106T08&msg=TC39%20Submission%20%20%20%20%20deadline)
+Deadline for advancement eligibility: [**November 6th, 2020, 10:00 CEST**](https://www.timeanddate.com/countdown/generic?p0=1440&iso=20201106T09&msg=TC39%20Submission%20%20%20%20%20deadline)
   - <sub>Note: this time is selected to be precisely 10 days prior to the start of the meeting</sub>
 
 1. Proposals not looking to advance may be added at any time; if after the deadline, please always use a pull request so that members are notified of changes.


### PR DESCRIPTION
The meeting was always planned to operate on Hungary local time.  Daylight savings has ended hence it is now UTC+1.