### PR TITLE
Include ordering invariant PR in tla discussion

### DIFF
--- a/2021/03.md
+++ b/2021/03.md
@@ -76,7 +76,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | stage | timebox | topic | presenter |
     |:-:|:-----:|:-------:|-------|-----------|
-    |   | 3     | 30m     | [top-level await](https://github.com/tc39/proposal-top-level-await) bug fixes ([PR](https://github.com/tc39/proposal-top-level-await/pull/161)) | TBD |
+    |   | 3     | 30m     | [top-level await](https://github.com/tc39/proposal-top-level-await) DFS ordering invariant normative change ([PR](https://github.com/tc39/proposal-top-level-await/pull/159)) and bug fixes ([PR](https://github.com/tc39/proposal-top-level-await/pull/161)) | TBD |
     |   | 2     | 45m     | [Temporal](https://github.com/tc39/proposal-temporal) for Stage 3 | TBD |
     |   | 1     | 15m     | [array-find-from-last](https://github.com/tc39-transfer/proposal-array-find-from-last) for stage 2 ([slides](https://drive.google.com/file/d/1rhER8TZ5GsHDzl8nLvo8qSIQCUXPw3AQ/view?usp=sharing)) | KWL |
     |   | 0     | 30m     | [JavaScript module fragments](https://github.com/littledan/proposal-module-fragments) for Stage 1 | Daniel Ehrenberg |


### PR DESCRIPTION
This updates the TLA discussion to include the normative DFS invariant change from https://github.com/tc39/proposal-top-level-await/pull/159 based on the scenario brought up by @sokra in the example at https://github.com/tc39/proposal-top-level-await/issues/158#issue-796269657.

//cc @littledan @codehag 