### PR TITLE
Fix table for proposals nominated to stage advancement in March meeting agenda

### DIFF
--- a/2021/03.md
+++ b/2021/03.md
@@ -77,7 +77,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | stage | timebox | topic | presenter |
     |:-:|:-----:|:-------:|-------|-----------|
-|   | 3     | 30m     | [top-level await update towards stage 4](https://github.com/tc39/proposal-top-level-await), DFS ordering invariant normative change ([PR](https://github.com/tc39/proposal-top-level-await/pull/159)) and bug fixes ([PR](https://github.com/tc39/proposal-top-level-await/pull/161)) | Yulia Startsev |
+    |   | 3     | 30m     | [top-level await update towards stage 4](https://github.com/tc39/proposal-top-level-await), DFS ordering invariant normative change ([PR](https://github.com/tc39/proposal-top-level-await/pull/159)) and bug fixes ([PR](https://github.com/tc39/proposal-top-level-await/pull/161)) | Yulia Startsev |
     |   | 2     | 45m     | [Temporal](https://github.com/tc39/proposal-temporal) for Stage 3 | TBD |
     |   | 1     | 15m     | [array-find-from-last](https://github.com/tc39-transfer/proposal-array-find-from-last) for stage 2 ([slides](https://drive.google.com/file/d/1rhER8TZ5GsHDzl8nLvo8qSIQCUXPw3AQ/view?usp=sharing)) | KWL |
     |   | 0     | 30m     | [JavaScript module fragments](https://github.com/littledan/proposal-module-fragments) for Stage 1 | Daniel Ehrenberg |


### PR DESCRIPTION
Currently it looks like this
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/1507086/108372276-b31c8a00-720f-11eb-97c0-f6a82b2a8829.png">
