### PR TITLE
add do/async do

### DIFF
--- a/2021/03.md
+++ b/2021/03.md
@@ -87,6 +87,8 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 2     | 20m     | [Error Cause](https://github.com/tc39/proposal-error-cause) for Stage 3 | Chengzhong Wu, Hemanth HM |
     |   | 1     | 15m     | [array-find-from-last](https://github.com/tc39-transfer/proposal-array-find-from-last) for stage 2 ([slides](https://drive.google.com/file/d/1rhER8TZ5GsHDzl8nLvo8qSIQCUXPw3AQ/view?usp=sharing)) | KWL |
     |   | 1     | 30m     | [Unicode set notation in regular expressions](https://github.com/tc39/proposal-regexp-set-notation) Stage 1 Update | MB |
+    |   | 1     | 30m     | [Do expressions](https://github.com/tc39/proposal-do-expressions/) for stage 2 ([slides](https://docs.google.com/presentation/d/1GXk1UwhaXijT0Rcn3_I4HmVGsdxM9cpYqcRvVjdzIoA/), [spec](https://tc39.es/proposal-do-expressions/)) | Kevin Gibbons |
+    |   | 1     | 10m     | [Async do expressions](https://github.com/tc39/proposal-async-do-expressions/) for stage 2 ([slides](https://docs.google.com/presentation/d/1hblummbrbRcQM8YL59701Q55obHZHC3IHSdKt2MIGtM/), [spec](https://tc39.es/proposal-async-do-expressions/)) | Kevin Gibbons |
     |   | 0     | 30m     | [JavaScript module fragments](https://github.com/littledan/proposal-module-fragments) for Stage 1 | Daniel Ehrenberg |
     |   | 2     | 30m     | [Collection Normalization](https://github.com/tc39/proposal-collection-normalization) move Set to follow on due to bikeshed, prep for Stage 3 | Bradley Farias |
 


### PR DESCRIPTION
This is after the currently-listed deadline, but it was listed as tomorrow until [a couple of hours ago](https://github.com/tc39/agendas/commit/ddccb43e04f7a0c79d1efccf0ec3542fd660f28e).

I've intentionally added async do out of order because it should be grouped with do expressions.