### PR TITLE
add security TG finalisation topic

### DIFF
--- a/2021/04.md
+++ b/2021/04.md
@@ -69,6 +69,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
+    | | 30m | chartering of [the security TG](https://docs.google.com/presentation/d/1p_Ae5sX2uk595_Gt-3Bnfs6VQfhrFt9Zo27pn6P-r8k/edit#slide=id.gb160eaf309_0_126) | TC39 chair group |
 
 1. Proposals
 


### PR DESCRIPTION
This TG was presented and received consensus at the January 2021 plenary. @ecmageneva asked for us to allow additional time for representatives to weigh in outside plenary (hopefully this has been sufficient time), and the chair group was tasked with prescribing TG leadership selection processes. I would like to reserve this time to officially charter the group and to hear from the chair group about the processes that they've chosen. @tc39/chair-group would one of you be able to present for this topic?