### PR TITLE
Add my time constraint on 2021/04

### DIFF
--- a/2021/04.md
+++ b/2021/04.md
@@ -119,6 +119,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 - Shane F. Carr is unavailable Thursday after 13:00 ET; wants to be present for all Intl- and Regex-related topics.
 - Please schedule NVC Training Proposal after "Requests for services from Ecma for TC39"
 - Please schedule the “set notation + properties of strings update” somewhere within 12:00–14:00 ET on Thursday April 22nd so both champions and all stakeholders can attend.
+- It's better to put Jack Works' agenda item at first 2 hours of the day, or any time before the Isolated Realms update presented.
 
 ## Dates and locations of future meetings
 


### PR DESCRIPTION
I'd like to present on one of the following time:

- First 2hrs of any day
- If that day has Isolated Realms update, any time before it is good 