### PR TITLE
Update scheduling constraint per chair request

### DIFF
--- a/2021/04.md
+++ b/2021/04.md
@@ -119,7 +119,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 - Frank Yung-Fong Tang and Shane F. Carr will not be available 12:30-14:00 PM ET on Tuesday April 20th nor after 1:30PM ET on Wednesday April 21st. 
 - Shane F. Carr is unavailable Thursday after 13:00 ET; wants to be present for all Intl- and Regex-related topics.
 - Please schedule NVC Training Proposal after "Requests for services from Ecma for TC39"
-- Please schedule the “set notation + properties of strings update” somewhere within 12:00–14:00 ET on Thursday April 22nd so both champions and all stakeholders can attend.
+- Please schedule the “set notation + properties of strings update” from 11:00–11:30 ET on Tuesday April 20th so both champions can attend.
 - It's better to put Jack Works' agenda item at first 2 hours of the day, or any time before the Isolated Realms update presented.
 - Peter Hoddie is unavailable for the first hour each day, but would like to be present for chartering of the security TG, Read-only ArrayBuffer, and ResizableArrayBuffer if scheduling allows.
 


### PR DESCRIPTION
I know it’s generally bad form to update scheduling constraints during a meeting, but in this case it was specifically requested by the chairs, who hope to save 1 whole day for all delegates. Context: https://github.com/tc39/agendas/commit/628667e10a03f548c901e3dd9bb1351592bee8bf#commitcomment-49629723

@gesa Please let me know if this time works for y'all. Thanks so much!