### PR TITLE
Delay enum proposal to next meeting

### DIFF
--- a/2021/12.md
+++ b/2021/12.md
@@ -103,7 +103,6 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 1     | 30m     | [RegExp Buffer Boundaries for Stage 2](https://github.com/tc39/proposal-regexp-buffer-boundaries) ([slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkfs-sKyEtV6B_S-poQ?e=U7ToKV)) | Ron Buckton |
     |   | 1     | 30m     | [Array.fromAsync](https://github.com/tc39/proposal-array-from-async/) for Stage 2 ([Slides](https://docs.google.com/presentation/d/1nEvxVJNya_-p2P0tCC8bofQ7-_eYef-b3FM9Dwd8Evw/)) | J. S. Choi |
     |   | 0     | 30m     | [Intl.Segmenter v2](https://github.com/FrankYFTang/proposal-intl-segmenter-v2) for Stage 1 ([Slides](https://docs.google.com/presentation/d/1ezpdee0r_ujHXDqqT4HHNYa2Q4VU7b4cMQWg6gQxLTk)) | Frank Yung-Fong Tang |
-    |   | 0     | 40m     | [enum for stage 1](https://github.com/Jack-Works/proposal-enum) for Stage 1 (slides tbd) | Jack Works |
 
 
 1. Longer or open-ended discussions


### PR DESCRIPTION
It seems like this meeting has a time overflow. And I also didn't ready to present this proposal yet. I prefer to delay it to the next meeting and communicate with other delegates about this proposal.