### PR TITLE
Add async iterator wrapper fix PR to 2022-01

### DIFF
--- a/2022/01.md
+++ b/2022/01.md
@@ -111,6 +111,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 ### Schedule constraints
 
 <!-- Be specific! Provide a full name, date and time range that they will or will not be available, and which sessions they are trying to prioritize. Satisfaction not guaranteed, but more information is useful. Conflicting constraints honored on a first-come, first served basis. -->
+- Mathieu Hofman (close async iterator wrapper fix PR) is not available Monday 24t. Any other day and time is fine.
 
 ## Dates and locations of future meetings
 

--- a/2022/01.md
+++ b/2022/01.md
@@ -66,6 +66,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
+    |   | 20m     | [Close sync iterator when async wrapper yields rejection](https://github.com/tc39/ecma262/pull/2600) | Mathieu Hofman |
 
 1. Overflow from previous meeting
 


### PR DESCRIPTION
I need to update the PR with the latest feedback and discussions, but will have that ready by end of the weekend. In the mean time I switched the PR back to draft status.