### PR TITLE
Add enum proposal for Jan 2022 meeting

### DIFF
--- a/2022/01.md
+++ b/2022/01.md
@@ -100,6 +100,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 60m     | presentation from KAIST research group | KAIST research group &amp; TC39 editor group |
     |   | 45m     | Let's talk about test262 maintenance and contribution | Shu-yu Guo |
     |   | 60m     | Holistic discussion of TC39 dataflow proposals ([JSC’s diagram](https://jschoi.org/21/es-dataflow/map/); [JSC’s article](https://jschoi.org/21/es-dataflow/); [Tab’s article](https://www.xanthir.com/b5Gd0)) | J. S. Choi |
+    |   | 45m     | [enum](https://github.com/Jack-Works/proposal-enum/) for stage 1 | Jack Works |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
https://github.com/Jack-Works/proposal-enum/

Note:
This proposal (my version) has _no_ design at all.

It's intended to start with identifying the design space before actual design.

I also want to form a champion group/incubator call at the meeting. Currently I added @rickbutton and @rwaldron.