### PR TITLE
Add slides to async wrapper close

### DIFF
--- a/2022/01.md
+++ b/2022/01.md
@@ -67,7 +67,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
-    |   | 20m     | [Close sync iterator when async wrapper yields rejection](https://github.com/tc39/ecma262/pull/2600) | Mathieu Hofman |
+    |   | 20m     | Close sync iterator when async wrapper closes. ([PR](https://github.com/tc39/ecma262/pull/2600), [Slides](https://docs.google.com/presentation/d/1W9EJoWOvi6jU1A2bwyixzOceoP_ASAeaOYER3Zy9P00)) | Mathieu Hofman |
 
 1. Overflow from previous meeting
 


### PR DESCRIPTION
Also slightly tweak the name, since there are 2 cases where the async wrapper should close the iterator