### PR TITLE
Add ShadowRealms clarification entry

### DIFF
--- a/2022/03.md
+++ b/2022/03.md
@@ -78,6 +78,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
+    |   | 10m     | [ShadowRealms clarification, wrapped exotic functions name w/ no prefix](https://github.com/tc39/proposal-shadowrealm/pull/348) | Leo Balter |
 
 1. Proposals
 


### PR DESCRIPTION
Ref https://github.com/tc39/proposal-shadowrealm/pull/348

In the TC39 Dec 2021 plenary we got consensus to set `name` and `length` for Wrapped Exotic functions within the ShadowRealms proposal. Even though, the meeting notes ended somehow ambiguous about the `name` property being prefixed with "wrapped " or not. The intention from the champions - as presented in that plenary - was to not use the prefix.