### PR TITLE
Add Stage 3 slot for RegExp v flag proposal

### DIFF
--- a/2022/03.md
+++ b/2022/03.md
@@ -91,6 +91,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 3     | 30m     | [Resizable buffers](https://github.com/tc39/proposal-resizablearraybuffer) normative changes for [TA#set](https://github.com/tc39/proposal-resizablearraybuffer/pull/87) and [TA#subarray](https://github.com/tc39/proposal-resizablearraybuffer/pull/93) | Shu-yu Guo |
     |   | 2     | 30m     | [Destructuring Private Fields](https://github.com/tc39/proposal-destructuring-private) for Stage 3 ([Tracker](https://github.com/tc39/proposal-destructuring-private/issues/2)) | Justin Ridgewell |
     |   | 2     | 60m     | [Decorators](https://github.com/tc39/proposal-decorators) for Stage 3 ([Tracker](https://github.com/tc39/proposal-decorators/issues/442)) | Chris Hewell Garrett |
+    |   | 2     | 30m     | [RegExp set notation + Unicode properties of strings](https://github.com/tc39/proposal-regexp-set-notation) for Stage 3 ([PR](https://github.com/tc39/ecma262/pull/2418), [spec preview with inline diffs](https://arai-a.github.io/ecma262-compare/?pr=2418)) | Mathias Bynens & Markus Scherer |
     |   | 0     | 30m     | [Logical Default Assignment](https://github.com/jun-sheaf/proposal-logical-default-assignment) | Randolf Jung |
     |   | 1     | 60m     | [Pattern matching](https://github.com/tc39/proposal-pattern-matching) for Stage 2 ([slides](https://docs.google.com/presentation/d/1sJoXU1ysK6eZn04pjnQ-1z6EetsVf9VfHeU0Ht8hiFQ)) | Tab Atkins-Bittner |
 


### PR DESCRIPTION
We’ve formally asked the Stage 3 reviewers to start reviewing back at the December meeting. Since then, we’ve already received and addressed a good amount of feedback. We’re hoping to get the Stage 3 reviews fully wrapped up before the March meeting; if not, the agenda item can be removed (or repurposed as a reminder to start reviewing / call for other Stage 3 reviewers).