### PR TITLE
Increasing timebox for Atomic Operators

### DIFF
--- a/2022/06.md
+++ b/2022/06.md
@@ -102,9 +102,9 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 1     | 60m     | [Grouped and Auto-Accessors](https://github.com/tc39/proposal-grouped-and-auto-accessors) for stage 2 ([draft spec](https://tc39.es/proposal-grouped-and-auto-accessors/), [slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkf5bHDNfAnGwyyzaKQ?e=Lgz7sc)) | Ron Buckton |
     |   | 1     | 60m     | [Import Reflection](https://github.com/tc39/proposal-import-reflection) status update & discussion (slides TBD) | Guy Bedford & Luca Casonato |
     |   | 0     | 30m     | [Duplicate named capture groups](https://github.com/bakkot/proposal-duplicate-named-capturing-groups) for stage 1, 2, or 3 | Kevin Gibbons |
-    |   | 0     | 30m     | [RegExp Atomic Operators](https://github.com/rbuckton/proposal-regexp-atomic-operators) for Stage 1 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkf5fz_Ayyt6gEMkBgQ?e=6eFHfI)) | Ron Buckton |
     |   | 0     | 30m     | Fatal Errors for Stage 1 (repo, slides TBD) | HE Shi-Jun |
     |   | 0     | 30m     | [`this` parameter](https://github.com/hax/proposal-this-parameter) for Stage 1, [slides](https://johnhax.net/2022/this-param/slide) | HE Shi-Jun |
+    |   | 0     | 60m     | [RegExp Atomic Operators](https://github.com/rbuckton/proposal-regexp-atomic-operators) for Stage 1 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkf5fz_Ayyt6gEMkBgQ?e=6eFHfI)) | Ron Buckton |
 
 1. Longer or open-ended discussions
 


### PR DESCRIPTION
I don't think we had sufficient time to discuss the proposal in the October, 2021 meeting. I'm increasing the expected timebox to account for discussion time.