### PR TITLE
Adds Draft spec link for RegExp Atomic Operators

### DIFF
--- a/2022/06.md
+++ b/2022/06.md
@@ -106,7 +106,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 0     | 30m     | [Duplicate named capture groups](https://github.com/bakkot/proposal-duplicate-named-capturing-groups) for stage 1, 2, or 3 | Kevin Gibbons |
     |   | 0     | 30m     | Fatal Errors for Stage 1 (repo, slides TBD) | HE Shi-Jun |
     |   | 0     | 30m     | [`this` parameter](https://github.com/hax/proposal-this-parameter) for Stage 1, [slides](https://johnhax.net/2022/this-param/slide) | HE Shi-Jun |
-    |   | 0     | 60m     | [RegExp Atomic Operators](https://github.com/rbuckton/proposal-regexp-atomic-operators) for Stage 1 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkf5fz_Ayyt6gEMkBgQ?e=6eFHfI)) | Ron Buckton |
+    |   | 0     | 60m     | [RegExp Atomic Operators](https://github.com/rbuckton/proposal-regexp-atomic-operators) for Stage 1 ([draft spec](https://rbuckton.github.io/proposal-regexp-atomic-operators/), [slides](https://1drv.ms/p/s!AjgWTO11Fk-Tkf5fz_Ayyt6gEMkBgQ?e=6eFHfI)) | Ron Buckton |
 
 1. Longer or open-ended discussions
 


### PR DESCRIPTION
Not strictly necessary for Stage 1, but worth including for reference.