### PR TITLE
Fix malformed ISO date in 2022-07 agenda

### DIFF
--- a/2022/07.md
+++ b/2022/07.md
@@ -14,7 +14,7 @@
 For meeting times in your timezone, visit [Temporal docs](https://tc39.es/proposal-temporal/docs/) and run the code below in the devtools console.
 
 ```js
-Temporal.ZonedDateTime.from('2022-07-19:00[America/Los_Angeles]')
+Temporal.ZonedDateTime.from('2022-07-19T10:00[America/Los_Angeles]')
   .withTimeZone(Temporal.Now.timeZone()) // your time zone
   .toLocaleString()
 ```


### PR DESCRIPTION
Current throws `Uncaught RangeError: invalid ISO 8601 string: 2022-07-19:00[America/Los_Angeles]`