### PR TITLE
links slides for "avoid mostly-redundant await in async `yield*`"

### DIFF
--- a/2022/07.md
+++ b/2022/07.md
@@ -66,7 +66,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |:-:|:-------:|-------|-----------|
     |   |      5m | [Only coerce once in the BigInt constructor](https://github.com/tc39/ecma262/pull/2812) | Kevin Gibbons |
     |   |     15m | [Allow host exotic objects to reject private fields](https://github.com/tc39/ecma262/pull/2807) | Kevin Gibbons |
-    |   |     30m | [Avoid triggering `throw` in corner case in async generators](https://github.com/tc39/ecma262/pull/2818) or [Avoid mostly-redundant await in async `yield*`](https://github.com/tc39/ecma262/pull/2819) | Kevin Gibbons |
+    |   |     30m | [Avoid triggering `throw` in corner case in async generators](https://github.com/tc39/ecma262/pull/2818) or [Avoid mostly-redundant await in async `yield*`](https://github.com/tc39/ecma262/pull/2819) - [slides](https://docs.google.com/presentation/d/1Ip-v0VNF8eWgN4mg5BkVuvLn-1tO4lKP70As8LRoMGc/edit?usp=sharing) | Kevin Gibbons |
     |   |     30m | [Always check regular expression flags by "flags"](https://github.com/tc39/ecma262/pull/2791) | Richard Gibson |
     |   |     20m | [Allow toString of a built-in function to output a computed property name](https://github.com/tc39/ecma262/pull/2695) | Richard Gibson |
 


### PR DESCRIPTION
This is after the advancement deadline, so I'm doing this by PR in the hopes it gets more visibility that way.