### PR TITLE
Add module expressions&declarations

### DIFF
--- a/2022/11.md
+++ b/2022/11.md
@@ -94,12 +94,14 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 3     | 30m     | [Intl DurationFormat](https://github.com/tc39/proposal-intl-duration-format) Stage 3 Update ([Slides TBD](#)) | Ujjwal Sharma |
     |   | 3     | 60m     | [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) Stage 3 update and request for "Ready to Ship" status ([slides](https://docs.google.com/presentation/d/183cYPeUjhzVRuZ0O-gwXqp6KtFYxxhgYodbr7XNo_9o/edit#slide=id.p37)) | Leo Balter |
     |   | 2     | 15m     | [Well-Formed Unicode Strings](https://github.com/tc39/proposal-is-usv-string) for Stage 3 ([slides](https://docs.google.com/presentation/d/1YXHuZ46ZwzR2zZs1V2FdT1oEGH13b6E6bpfX0w9i1EA)) | Michael Ficarra |
-    |   | 2     | 30m     | [Module and ModuleSource constructors](https://github.com/tc39/proposal-compartments/blob/master/0-module-and-module-source.md) for stage 2 (slides TBW, [spec](https://tc39.es/proposal-compartments/0-module-and-module-source.html)) | Caridy Patiño |
+    |   | 2     | 30m     | [Module expressions](https://github.com/tc39/proposal-module-expressions) (was "Module blocks") Stage 2 update (slides TBD, [spec](https://tc39.es/proposal-module-expressions/)) | Nicolò Ribaudo |
     |   | 2     | 45m     | [Set methods](https://github.com/tc39/proposal-set-methods) for Stage 3 ([slides](https://docs.google.com/presentation/d/1SvBt_0yPuK39Zz7Tg7nBdPGJkZvTlJ2UOYrDuiX60Ks), [spec](https://tc39.es/proposal-set-methods/)) | Kevin Gibbons |
     |   | 2     | 45m     | [iterator helpers](https://github.com/tc39/proposal-iterator-helpers) for stage 3 ([slides](https://docs.google.com/presentation/d/1npPCpovE6NtFPFvagaq8eoX2VLXM6Tac_fl--7_NrzY/edit)) | Michael Ficarra |
     |   | 2     | 45m     | [Import reflection](https://github.com/tc39/proposal-import-reflection) update (slides TBW, [spec](https://tc39.es/proposal-import-reflection)) | Guy Bedford & Luca Casonato |
     |   | 2     | 60m     | [Records & Tuples](https://github.com/tc39/proposal-record-tuple) discussion (slides TBC) | TBC |
     |   | 1     | 30m     | [await operations](https://github.com/tc39/proposal-await.ops/) for Stage 2 ([slides](https://docs.google.com/presentation/d/1bB63gV3H9qUvMg4FUHAu9jv2E7wL65jGZd_f46tIc10/edit?usp=sharing)) | Jack Works |
+    |   | 1     | 30m     | [Module and ModuleSource constructors](https://github.com/tc39/proposal-compartments/blob/master/0-module-and-module-source.md) for stage 2 (slides TBW, [spec](https://tc39.es/proposal-compartments/0-module-and-module-source.html)) | Caridy Patiño |
+    |   | 1     | 30m     | [Module declarations](https://github.com/tc39/proposal-module-declarations) (was "Module fragments") for Stage 2 (slides TBD, [spec](https://tc39.es/proposal-module-declarations/)) | Nicolò Ribaudo |
     |   | 0     | 30m     | [Intl Era and MonthCode](https://github.com/FrankYFTang/proposal-intl-era-monthcode) for Stage 1 (slides TBW, [spec](https://frankyftang.github.io/proposal-intl-era-monthcode)) | Frank Yung-Fong Tang |
     |   | 0     | 30m     | [Intl MessageResource](https://github.com/eemeli/proposal-intl-message-resource) for Stage 1 (slides TBW, [spec](https://github.com/eemeli/proposal-intl-message-resource)) | Eemeli Aro |
 
@@ -130,10 +132,11 @@ _Schedule constraints should be supplied here **48 hours** before the meeting be
 
 <!-- Constraints supplied more than 48 hours before the meeting should go here -->
 
+- The "module declarations" topic should come right after "module expressions" (Nicolò Ribaudo)
+
 #### Late-breaking Schedule Constraints
 
 <!-- Constraints supplied less than 48 hours before the meeting should go here -->
-
 
 ## Dates and locations of future meetings
 


### PR DESCRIPTION
Part of the discussion will probably apply to both proposals, so I would like to have them one after the other. I was considering putting them under a single agenda item, but since:
- they are at different stages
- one is a status update, the other one is asking for advancement

I ended up using two topics with a schedule constraint that I would like to have them together. It's not exactly how schedule constraint are meant to be used: is it ok?

Also I moved the Module/ModuleSource proposal to the correct position in the table, since it's not at Stage 2 yet (cc @kriskowal / @caridy)