### PR TITLE
2022.11: Move schedule constraints to the correct sub-section

### DIFF
--- a/2022/11.md
+++ b/2022/11.md
@@ -137,17 +137,16 @@ _Schedule constraints should be supplied here **48 hours** before the meeting be
 
 <!-- Be specific! Provide a full name, date and time range that they will or will not be available, and which sessions they are trying to prioritize. Satisfaction not guaranteed, but more information is useful. Conflicting constraints honored on a first-come, first served basis. -->
 
- - Leo Balter is attending from California, preference for the ShadowRealm topic being discussed at the the last hour of the meeting, any of the days.
- - Alex Vincent is attending from California and would prefer to present Mass Proxy Revocation either at the beginning or the end of the meeting, any of the days.
-- Frank Yung-Fong Tang is attending from California, cannot attend afternoon on Thursday, December 1 and prefer to present all his topics in one batch, either in the morning of Wednesday, November 30 or the morning of Thursday, December 1.
-
 #### Normal Constraints
 
 <!-- Constraints supplied more than 48 hours before the meeting should go here -->
 
+ - Leo Balter is attending from California, preference for the ShadowRealm topic being discussed at the the last hour of the meeting, any of the days.
 - The "module declarations" topic should come right after "module expressions" (Nicolò Ribaudo)
 - Shu-yu Guo might not be able to attend Thursday, December 1; lowest priority items for @syg are Intl-related, so preference for Intl items on that day.
+ - Alex Vincent is attending from California and would prefer to present Mass Proxy Revocation either at the beginning or the end of the meeting, any of the days.
 - Philip Chimento is available either the first or last hour of the meeting on any day, to present Temporal. Would prefer to be able to attend "Is ECMA-402 allowed to extend ECMA-262 prototypes?" as well, but that's not as high of a priority.
+- Frank Yung-Fong Tang is attending from California, cannot attend afternoon on Thursday, December 1 and prefer to present all his topics in one batch, either in the morning of Wednesday, November 30 or the morning of Thursday, December 1.
 - Santiago Díaz cannot attend Thursday, December 1 and needs to be present for "Prototype pollution mitigation / Symbol.proto"
 
 #### Late-breaking Schedule Constraints


### PR DESCRIPTION
As far as I understand, all constraints should go either in the "Normal constraints" or in the "Late-breaking schedule constraints" sections.

It's important that they are properly sorted, because as the comment in the agenda says "Conflicting constraints honored on a first-come, first served basis". This PR sorts them in the same order as they were committed.