### PR TITLE
update January meeting dates

### DIFF
--- a/2022/11.md
+++ b/2022/11.md
@@ -161,7 +161,7 @@ _Schedule constraints should be supplied here **48 hours** before the meeting be
 
 | Dates                    | Location            | Host                 |
 |--------------------------|---------------------|----------------------|
-| 2023-01-23 to 2023-01-26 | _Remote: "Boston"_  |                      |
+| 2023-01-30 to 2023-02-02 | _Remote: "Boston"_  |                      |
 | 2023-03-21 to 2023-03-23 | Seattle, US         | F5                   |
 | 2023-05-15 to 2023-05-18 | _Remote: "Chicago"_ |                      |
 | 2023-07-11 to 2023-07-13 | Bergen, Norway      | University of Bergen |


### PR DESCRIPTION
This change corresponds to https://github.com/tc39/agendas/pull/1291, but updates the dates listed at the end of last meeting's agenda, which I sometimes refer to.