### PR TITLE
fix date in temporal snippet

### DIFF
--- a/2023/01.md
+++ b/2023/01.md
@@ -14,7 +14,7 @@
 For meeting times in your timezone, visit [Temporal docs](https://tc39.es/proposal-temporal/docs/) and run the code below in the devtools console.
 
 ```js
-Temporal.ZonedDateTime.from('2023-01-13T10:00[America/New_York]')
+Temporal.ZonedDateTime.from('2023-01-30T10:00[America/New_York]')
   .withTimeZone(Temporal.Now.timeZone()) // your time zone
   .toLocaleString()
 ```


### PR DESCRIPTION
https://github.com/tc39/agendas/pull/1291 probably should have included this, but even before then it was off by 10 - I'm guessing a typo?