### PR TITLE
Request TC39 adoption of W3C Guidelines

### DIFF
--- a/2023/01.md
+++ b/2023/01.md
@@ -65,6 +65,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
+    |   |15-30    | Adopt [W3C Guidelines](https://w3ctag.github.io/design-principles/) as advisory precedent for TC39 | Chairs |
 
 1. Overflow from previous meeting
 


### PR DESCRIPTION
I ask the plenary to make the [W3C Design Guidelines](https://w3ctag.github.io/design-principles/) advisory precedent which should be taken into account by all proposals to enhance consistency across the web-plattform.

Given this is already a standard document by W3C we ask the chairs to host the discussion. A conclusion would be consensus and clarity on how the plenary believes these design guidelines should impact TC39 work and whether and how they should influence us.