### PR TITLE
Add slides for Async Resource Management

### DIFF
--- a/2023/01.md
+++ b/2023/01.md
@@ -97,7 +97,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 3     | 45m     | [Temporal](https://github.com/tc39/proposal-temporal) Stage 3 update and normative PRs (slides TBD, [spec](https://tc39.es/proposal-temporal)) | Philip Chimento |
     |   | 3     | 60m     | Problems with [import assertions](https://github.com/tc39/proposal-import-assertions/) for module types and a possible general solution ([HTML issue](https://github.com/whatwg/html/issues/7233)) | Nicolò Ribaudo |
     |   | 2     | 30m     | [ArrayBuffer transfer](https://github.com/tc39/proposal-arraybuffer-transfer) for Stage 3 | Shu-yu Guo |
-    |   | 2     | 60m     | [Async Explicit Resource Management](https://github.com/tc39/proposal-async-explicit-resource-management/) for Stage 3? (slides TBD, [spec](https://github.com/tc39/proposal-async-explicit-resource-management/pull/6)) | Ron Buckton |
+    |   | 2     | 60m     | [Async Explicit Resource Management](https://github.com/tc39/proposal-async-explicit-resource-management/) for Stage 3? ([slides](https://1drv.ms/p/s!AjgWTO11Fk-TkoUrpbKj1NY_bFBEzg?e=GmlwFX), [spec](https://github.com/tc39/proposal-async-explicit-resource-management/)) | Ron Buckton |
     |   | 1     | 30m     | [Intl era and monthCode](https://github.com/tc39/proposal-intl-era-monthcode) for Stage 2 (slides TBW, [spec](https://tc39.es/proposal-intl-era-monthcode)) | Frank Yung-Fong Tang |
     |   | 1     | 30m     | [Symbol Predicates](https://github.com/tc39/proposal-symbol-predicates) for stage 2 | Jordan Harband |
     |   | 1     | 60m     | [getIntrinsic, with an iterator](https://github.com/tc39/proposal-get-intrinsic/pull/17) for stage 2 | Jordan Harband |
@@ -108,7 +108,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     | ✓ | timebox | topic | presenter |
     |:-:|:-------:|-------|-----------|
     |   | 30m     | Discuss SuppressedError argument overlap: `error` and `cause` ([issue](https://github.com/tc39/proposal-explicit-resource-management/pull/117#issuecomment-1360473420)) | Jordan Harband |
-    |   | 30m     | Decorator `context.access` object API (slides TBD, [issue](https://github.com/tc39/proposal-decorators/issues/494)) | Ron Buckton |
+    |   | 30m     | Decorator `context.access` object API ([issue](https://github.com/tc39/proposal-decorators/issues/494)) | Ron Buckton |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
Also removes the TBD slides for the `context.access` topic, will directly discuss linked issue instead.