### PR TITLE
Add scheduling constraint for "Decorator `context.access` object API"

### DIFF
--- a/2023/01.md
+++ b/2023/01.md
@@ -145,6 +145,7 @@ _Schedule constraints should be supplied here **48 hours** before the meeting be
 #### Late-breaking Schedule Constraints
 
 <!-- Constraints supplied less than 48 hours before the meeting should go here -->
+- The outcome of "Decorator `context.access` object API" will affect the TypeScript 5.0 RC at the end of February and needs to be discussed this meeting.
 
 
 ## Dates and locations of future meetings


### PR DESCRIPTION
There seems to be enough time remaining in the agenda that this shouldn't overflow to the next meeting, but I want to make sure that this has high enough priority to be discussed this meeting if the schedule shifts.