### PR TITLE
Add topic for decorator/export ordering for January 2023 meeting.

### DIFF
--- a/2023/01.md
+++ b/2023/01.md
@@ -114,6 +114,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |:-:|:-------:|-------|-----------|
     |   | 30m     | Discuss SuppressedError argument overlap: `error` and `cause` ([issue](https://github.com/tc39/proposal-explicit-resource-management/pull/117#issuecomment-1360473420)) | Jordan Harband |
     |   | 30m     | Decorator `context.access` object API ([issue](https://github.com/tc39/proposal-decorators/issues/494)) | Ron Buckton |
+    |   | 30m     | Decorators and `export` Ordering ([issue](https://github.com/tc39/proposal-decorators/issues/69), [slides](https://github.com/DanielRosenwasser/tc39-2023-01/blob/main/Decorator%20and%20export%20Ordering.pdf) | Daniel Rosenwasser, Ron Buckton |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 
@@ -146,6 +147,7 @@ _Schedule constraints should be supplied here **48 hours** before the meeting be
 
 <!-- Constraints supplied less than 48 hours before the meeting should go here -->
 - The outcome of "Decorator `context.access` object API" will affect the TypeScript 5.0 RC at the end of February and needs to be discussed this meeting.
+- The outcome of "Decorators and `export` Ordering" will affect the TypeScript 5.0 RC at the end of February and needs to be discussed this meeting.
 
 
 ## Dates and locations of future meetings


### PR DESCRIPTION
Given the discussion in https://github.com/tc39/proposal-decorators/issues/69, this topic is something we really need to discuss for the January meeting, since it will inform what we ship in TypeScript 5.0 RC.