### PR TITLE
Confirm meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ TC39 meeting agendas
 | Confirmed | Future Dates             | Location            | Host                 |
 |-----------|--------------------------|---------------------|----------------------|
 |  ✔        | 2023-03-21 to 2023-03-23 | Seattle, US         | F5                   |
-|           | 2023-05-15 to 2023-05-18 | _Remote: "Chicago"_ |                      |
+|  ✔        | 2023-05-15 to 2023-05-18 | _Remote: "Chicago"_ |                      |
 |           | 2023-07-11 to 2023-07-13 | Bergen, Norway      | University of Bergen |
 |           | 2023-09-26 to 2023-09-28 | Tokyo, Japan        | Bloomberg            |
-|           | 2023-11-27 to 2023-11-30 | _Remote: "SF"_      |                      |
+|  ✔        | 2023-11-27 to 2023-11-30 | _Remote: "SF"_      |                      |
 </details>
 <!-- AGENDA_LIST:START (TC39) -->
 <details open>


### PR DESCRIPTION
We only do two-month-ahead surveys to confirm hybrid meetings.  Remote meetings can be considered to be solid.  So I am marking the remote meetings as confirmed.