### PR TITLE
Add type annotations update to agenda & schedule constraints

### DIFF
--- a/2023/03.md
+++ b/2023/03.md
@@ -96,6 +96,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 1 | 30m | [Float16Array](https://github.com/tc39/proposal-float16array/tree/main) for stage 2 & 3 ([spec text](https://tc39.es/proposal-float16array/), [slides](https://docs.google.com/presentation/d/1dwAZG2TFK4GiXIk5nir5m7JkB4_VVUWmd4QWxpRgrn4/)) | Kevin Gibbons |
     |   | 1 | 30m | [Decimal](https://github.com/tc39/proposal-decimal/) stage 1 update (slides TBD) | Jesse Alama |
     |   | 1 | 30m | [Class Method Parameter Decorators](https://github.com/rbuckton/proposal-class-method-parameter-decorators) for stage 1 (slides TBD) | Ron Buckton |
+    |   | 1 | 45m | Type annotations update ([repo](https://github.com/tc39/proposal-type-annotations/), [slides](https://docs.google.com/presentation/d/1OraKn6TUdmtug-lkgijq-43Xou_1lB1_DJ54x6ssnRY/edit?usp=sharing)) | Asumu Takikawa |
     |   | 1 | 60m | Shared structs update: prototype implementation, challenges, and performance (slides TBD) | Shu-yu Guo |
     |   | 1 | 60m | Async Context for stage 2 ([spec text](https://tc39.es/proposal-async-context/), [slides](https://docs.google.com/presentation/d/1LLcZxYyuQ1DhBH1htvEFp95PkeYM5nLSrlQoOmWpYEI/edit#slide=id.p)) | Justin Ridgewell, Chengzhong Wu |
     |   | 0 | 30m | Await Dictionary for stage 1 ([repo](https://github.com/acutmore/proposal-await-dictionary), [slides](https://docs.google.com/presentation/d/1UplIvpgqYTdWeBQO8DrHvYAXYEz-KG30GcJXAz_h50M/)) | Ashley Claymore |
@@ -133,6 +134,7 @@ _Schedule constraints should be supplied here **48 hours** before the meeting be
 - Chengzhong Wu is attending from Hangzhou, preference for the Async Contexts topic being discussed at the first two hours of the meeting, any of the days.
 - Yulia Startsev is only available for 1 hour in the mornings. Prefer to present topics at the end of committee (happy to also fall off the agenda if proposals need more time).
 - The "Import reflection update" topic should be scheduled before the "Import assertions/attributes for Stage 3" topic. Ideally these are scheduled directly after each other.
+- Asumu Takikawa will be unavailable on March 23rd due to conflicting meetings and would prefer that the type annotations update be scheduled on either the 21st or 22nd.
 
 #### Late-breaking Schedule Constraints
 


### PR DESCRIPTION
Adds an agenda item for an update on the type annotations proposal (no stage advancement requested) plus a schedule constraint.