### PR TITLE
Add slides link for Time Zone Canonicalization proposal

### DIFF
--- a/2023/03.md
+++ b/2023/03.md
@@ -105,7 +105,7 @@ Supporting materials includes slides, a link to the proposal repository, a link 
     |   | 0 | 45m | [Class Method Parameter Decorators](https://github.com/rbuckton/proposal-class-method-parameter-decorators) for stage 1 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-TkodwnfnGJ4--QyAsrw?e=c7blVv)) | Ron Buckton |    
     |   | 0 | 30m | Await Dictionary for stage 1 ([repo](https://github.com/acutmore/proposal-await-dictionary), [slides](https://docs.google.com/presentation/d/1UplIvpgqYTdWeBQO8DrHvYAXYEz-KG30GcJXAz_h50M/)) | Ashley Claymore |
     |   | 0 | 30m | `Promise.withResolvers` for stage 1 ([repo](https://github.com/peetklecha/proposal-promise-with-resolvers), [slides](https://docs.google.com/presentation/d/18CqQc6GfZJBWmT7li2nqfvrSFhpNwtQWPfSXhAwo-Bo/)) | Peter Klecha |
-    |   | 0 | 30m | Handling Time Zone Canonicalization Changes for stage 1 ([repo](https://github.com/justingrant/proposal-canonical-tz#readme), slides will summarize [this content](https://github.com/justingrant/proposal-canonical-tz#handling-time-zone-canonicalization-changes)) | Justin Grant, Richard Gibson |
+    |   | 0 | 30m | Time Zone Canonicalization for stage 1 ([repo](https://github.com/justingrant/proposal-canonical-tz#readme), [slides](https://docs.google.com/presentation/d/13vW8JxkbzyzGubT5ZkqUIxtpOQGNSUlguVwgcrbitog) summarize [this content](https://github.com/justingrant/proposal-canonical-tz#handling-time-zone-canonicalization-changes)) | Justin Grant, Richard Gibson |
 
 1. Longer or open-ended discussions
 


### PR DESCRIPTION
Add slides link so reviewers won't have to read as much vs. the previous longform writeup.

Same content, just shorter. 

Also shortened the name of the proposal because I got feedback that the old name was a mouthful.