### PR TITLE
Add Time Zone Canonicalization proposal for Stage 2

### DIFF
--- a/2023/05.md
+++ b/2023/05.md
@@ -110,6 +110,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |   | 2 | 45m | [Float16Array](https://github.com/tc39/proposal-float16array) for stage 3 ([slides](https://docs.google.com/presentation/d/1gBVaE4KV9JhRxG_V4_xjLW7P18lnKCDJEIktpi6eIxs/edit), [spec](http://tc39.es/proposal-float16array/)) | Kevin Gibbons |
     |   | 2 | 45m | [Source Phase Imports](https://github.com/tc39/proposal-import-reflection) for stage 3 (slides tbd, [spec](https://github.com/tc39/proposal-import-reflection/pull/36)) | Luca Casonato & Guy Bedford |
     |   | 1 | 30m | [Base64 for Uint8Array](https://github.com/tc39/proposal-arraybuffer-base64) for stage 2 ([slides](https://docs.google.com/presentation/d/1es04vDFcRKSYdj9gsNm2pjgIysHZkBa0k6Ds3kle5to/), [spec](https://tc39.es/proposal-arraybuffer-base64/spec/)) | Kevin Gibbons |
+    |   | 1 | 30m | [Time Zone Canonicalization](https://github.com/justingrant/proposal-canonical-tz#readme) for stage 2 ([slides](https://docs.google.com/presentation/d/111ycHJtLQ7mZkebv8rBfF6KKOSJfIeAXi2oNL_orOVs), [spec](https://tc39.es/proposal-canonical-tz/))  | Justin Grant, Richard Gibson |
     |   | 0 | 30m | [Intl ZonedDateTimeFormat](https://github.com/FrankYFTang/intl-zoneddatetimeformat) for stage 1 (slides TBW) | Frank Yung-Fong Tang |
 
 1. Longer or open-ended discussions


### PR DESCRIPTION
This proposal only has only ~10 lines of normative spec changes, plus one editorial paragraph. I wasn't sure of the best way to communicate these spec changes for Stage 2. As a starting point I screenshotted the changes into slides and linked my "spec" link in this PR to those slides. 

I could also link to the (small) spec HTML file.  But the slides are probably the easiest way to review the changes, so that's what I linked to in this agenda PR. If that's not correct, let me know!
