### PR TITLE
Fix typo in Temporal code sample

### DIFF
--- a/2023/07.md
+++ b/2023/07.md
@@ -13,7 +13,7 @@
 For meeting times in your timezone, visit [Temporal docs](https://tc39.es/proposal-temporal/docs/) and run the code below in the devtools console.
 
 ```js
-Temporal.ZonedDateTime.from('2023-07-01T10:00[Europe/Oslo]')
+Temporal.ZonedDateTime.from('2023-07-11T10:00[Europe/Oslo]')
   .withTimeZone(Temporal.Now.timeZoneId()) // your time zone
   .toLocaleString()
 ```


### PR DESCRIPTION
The wrong date was on the agenda. 