### PR TITLE
Add note to put schedule constraints in the relevant section

### DIFF
--- a/2023/11.md
+++ b/2023/11.md
@@ -138,6 +138,8 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
 *Schedule constraints should be supplied here **48 hours** before the meeting begins so that the Chairs can take them into account when preparing the schedule.*
 
+<!-- DO NOT PUT YOUR CONSTRAINTS HERE! Put them in one of the next sections: either "Normal Constraints" or "Late-breaking Schedule Constraints" -->
+
 <!-- Be specific! Provide a full name, date and time range that they will or will not be available, and which sessions they are trying to prioritize. Satisfaction not guaranteed, but more information is useful. Conflicting constraints honored on a first-come, first served basis. -->
 
 #### Normal Constraints

--- a/template.md
+++ b/template.md
@@ -133,6 +133,8 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
 *Schedule constraints should be supplied here **48 hours** before the meeting begins so that the Chairs can take them into account when preparing the schedule.*
 
+<!-- DO NOT PUT YOUR CONSTRAINTS HERE! Put them in one of the next sections: either "Normal Constraints" or "Late-breaking Schedule Constraints" -->
+
 <!-- Be specific! Provide a full name, date and time range that they will or will not be available, and which sessions they are trying to prioritize. Satisfaction not guaranteed, but more information is useful. Conflicting constraints honored on a first-come, first served basis. -->
 
 #### Normal Constraints


### PR DESCRIPTION
If we have the "normal constraints" section we should use it