### PR TITLE
Add presentation on TCQ reloaded

### DIFF
--- a/2023/11.md
+++ b/2023/11.md
@@ -110,6 +110,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |   | 2m  | Recruiting people interested in JSX to join the [matrix room](https://matrix.to/#/#jsx:matrix.org) | Jack Works |
     |   | 10m | add stage names back to process document ([PR](https://github.com/tc39/process-document/pull/36)) | Michael Ficarra |
     |   | 10m | publishing an [FAQs document](https://github.com/tc39/faq) | Michael Ficarra |
+    |   | 20m | present TCQ reloaded update and get initial feedback | Christian Ulbrich |
 
 1. Proposals
 


### PR DESCRIPTION
Hi everyone, TCQ is alive and kicking:
![Screenshot 2023-11-17 at 15 27 35](https://github.com/tc39/agendas/assets/160147/03ce9719-1328-4091-9265-5aca2818ae33)

Forgive us childish test data. Sometimes we even might grow up.

We would like to present our efforts on getting TCQ up and running and how to continue its evolution. For the curious have a look at https://github.com/zalari/tcq , although that spoil things quite a bit... 