### PR TITLE
Add layering PR along with ESM source phase update

### DIFF
--- a/2024/04.md
+++ b/2024/04.md
@@ -136,7 +136,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |   | 2     | 60m     | [Array.isTemplateObject](https://github.com/tc39/proposal-array-is-template-object) next steps | Daniel Ehrenberg |
     |   | 1     | 15m     | [`Atomics.microwait()`](https://github.com/syg/proposal-atomics-microwait) (without mini wait) for stage 2 ([slides](https://docs.google.com/presentation/d/1Sb4Qaa5F8ZM9X0kxv5e-Wh5CbT1ZoryeCtVShoVhu8Y/edit?usp=sharing)) | Shu-yu Guo |
     |   | 1     | 30m     | `eval`/`new Function` changes for Trusted Types as Normative PR or Stage 3 ([PR](https://github.com/tc39/ecma262/pull/3294), [slides](https://docs.google.com/presentation/d/14AjvbW2-aNvlirB-7pPhIAeM7oWKtjqONRcyp9ID7gg/edit?usp=sharing)) | Nicolò Ribaudo |
-    |   | 1     | 30m     | [ESM Source Phase](https://github.com/tc39/proposal-esm-phase-imports) status update | Guy Bedford |
+    |   | 1     | 30m     | [ESM Source Phase](https://github.com/tc39/proposal-esm-phase-imports) status update and layering change (https://github.com/tc39/proposal-source-phase-imports/pull/62) | Guy Bedford |
     |   | 1     | 30m     | [Module sync assert](https://github.com/tc39/proposal-module-sync-assert) for stage 2 | Jack Works |
     |   | 1     | 30m     | [Intl.MessageFormat](https://github.com/tc39/proposal-intl-messageformat) status update, maybe for stage 0? | Eemeli Aro |
     |   | 1     | 30m     | [Discard Bindings](https://github.com/tc39/proposal-discard-binding) for Stage 2 ([slides](https://1drv.ms/p/s!AjgWTO11Fk-TkqpoWw0poDW3dawBQg?e=O3UP1c), [spec](https://tc39.es/proposal-discard-binding/)) | Ron Buckton |


### PR DESCRIPTION
Updates the agenda item for the ESM source phase to also include the new layering update in https://github.com/tc39/proposal-source-phase-imports/pull/62. There is a very close conceptual relation here, so having it in the same agenda item works out.