### PR TITLE
Add needs-consensus PR item for ECMA-402 #877

### DIFF
--- a/2024/06.md
+++ b/2024/06.md
@@ -95,6 +95,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
+    |   20m   | ECMA-402 PR [#787](https://github.com/tc39/ecma402/pull/877): Specify time zone IDs to reduce divergence between engines ([slides](https://docs.google.com/presentation/d/1U_kNIpJb89LTSFh7BBiFIJSpW_epDSnzn4XKtER4IyQ/edit?usp=sharing))| Justin Grant |
 
 1. Overflow from previous meeting
 

--- a/2024/06.md
+++ b/2024/06.md
@@ -95,7 +95,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
-    |   20m   | ECMA-402 PR [#787](https://github.com/tc39/ecma402/pull/877): Specify time zone IDs to reduce divergence between engines ([slides](https://docs.google.com/presentation/d/1U_kNIpJb89LTSFh7BBiFIJSpW_epDSnzn4XKtER4IyQ/edit?usp=sharing))| Justin Grant |
+    |   20m   | ECMA-402 PR [#877](https://github.com/tc39/ecma402/pull/877): Specify time zone IDs to reduce divergence between engines ([slides](https://docs.google.com/presentation/d/1U_kNIpJb89LTSFh7BBiFIJSpW_epDSnzn4XKtER4IyQ/edit?usp=sharing))| Justin Grant |
 
 1. Overflow from previous meeting
 


### PR DESCRIPTION
Add agenda item for:

Normative: specify time zone ID requirements to reduce divergence between engines https://github.com/tc39/ecma402/pull/877