### PR TITLE
Propose / schedule Nova engine talk

### DIFF
--- a/2024/06.md
+++ b/2024/06.md
@@ -108,6 +108,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
     | 10m     | Status of TCQ reloaded | Christian Ulbrich |
+    | 30m     | Nova JavaScript Engine - Exploring a data-oriented engine design | Aapo Alasuutari |
 
 1. Proposals
 


### PR DESCRIPTION
Invited by Luca and Dan E, a talk on an experimental engine interpreting the ECMAScript specification in a data-oriented way; the intention is to motivate and encourage new ways to look at the language.

The talk was given at Web Engines Hackfest and received a fair bit of interest and spawned this invitation to take the talk to TC39. The talk is approximately 25 minutes in length, though at WEHF the QA after took it to 37 minutes in total length. I was instructed to open a pull request to add the talk to the agenda to get the talk scheduled.

On the actual scheduling side, Wednesday 19th would work the best for me but any day is doable.