### PR TITLE
add Intl.DurationFormat: Display negative sign on leading numeric-style zeroes

### DIFF
--- a/2024/07.md
+++ b/2024/07.md
@@ -96,6 +96,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
+    | 10m | Intl.DurationFormat: Display negative sign on leading numeric-style zeroes ([PR](https://github.com/tc39/proposal-intl-duration-format/pull/207)) | Ben Allen |
     | 20m | Normative: fully define Math.sqrt ([PR](https://github.com/tc39/ecma262/pull/3345)) | Michael Ficarra |
     | 20m | Normative Conventions: pretend primitives aren't iterable ([PR](https://github.com/tc39/how-we-work/pull/152)) | Michael Ficarra |
     | 30m | Avoid capturing lexical context in *indirect* eval ([PR](https://github.com/tc39/ecma262/pull/3374)) | Nicolò Ribaudo |


### PR DESCRIPTION
Previous versions of the spec failed to account for the possibility that negative durations could start with zero-valued hours or minutes values.