### PR TITLE
2024.10: Add import defer slides, extend timebox, update constraints

### DIFF
--- a/2024/10.md
+++ b/2024/10.md
@@ -174,7 +174,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 - Dominic Farolino can only present the `Observable` API between 10am JST and
   1pm JST, either Tuesday the 8th, or Wednesday the 9th.
 
-- Nicolò Ribaudo prefers to present in the afternoons
+- Nicolò Ribaudo prefers to present in the afternoons, and prefers the JSSugar discussion to happen on the last day.
 
 - Guy Bedford is available to present before 2pm JST any day, with a preference for 1pm - 2pm JST
 

--- a/2024/10.md
+++ b/2024/10.md
@@ -122,7 +122,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | 3   | 15m | [`Promise.try`](https://github.com/tc39/proposal-promise-try/issues/15) for Stage 4 | Jordan Harband |
     | 3   | 20m | [Import Attributes](https://github.com/tc39/proposal-import-attributes) and [JSON modules](https://github.com/tc39/proposal-json-modules) for stage 4 (https://github.com/tc39/ecma262/pull/3057, https://github.com/tc39/ecma262/pull/3391) | Nicolò Ribaudo |
     | 2.7 | 15m | [Math.sumPrecise](https://github.com/tc39/proposal-math-sum) for stage 3 & last chance to suggest other names ([tests](https://github.com/tc39/test262/pull/4049)) | Kevin Gibbons |
-    | 2.7 | 15m | [import defer](https://github.com/tc39/proposal-defer-import-eval/) updates regarding evaluation triggers ([PR](https://github.com/tc39/proposal-defer-import-eval/pull/49)) | Nicolò Ribaudo |
+    | 2.7 | 30m | [import defer](https://github.com/tc39/proposal-defer-import-eval/) updates regarding evaluation triggers ([slides](https://docs.google.com/presentation/d/1yFbqn6px5rIwAVjBbXgrYgql1L90tKPTWZq2A5D6f5Q/edit)) | Nicolò Ribaudo |
     | 2.7 | 45m | [Atomics.pause](https://github.com/tc39/proposal-atomics-microwait) for stage 3 ([spec](https://tc39.es/proposal-atomics-microwait/)) | Shu-yu Guo |
     | 2   | 20m | [Error.isError](https://github.com/tc39/proposal-is-error/issues/7) for stage 2.7 | Jordan Harband |
     | 2   | 30m | [Map.emplace](https://github.com/tc39/proposal-upsert) stage 2 update ([Slides](https://docs.google.com/presentation/d/1l95mluNq5GqJCj-4o1BqihlufnKuRF2rualJxfOvGu4/))| Daniel Minor |


### PR DESCRIPTION
I was hoping for this to be a quick update but unfortunately we found a bigger problem and I need committee input on which direction to take.