### PR TITLE
Extend Thursday to 5pm

### DIFF
--- a/2024/10.md
+++ b/2024/10.md
@@ -6,7 +6,7 @@
 - **Dates and times**:
   - 10:00 to 17:00 JST (Asia/Tokyo) on 8 October 2024
   - 10:00 to 17:00 JST (Asia/Tokyo) on 9 October 2024
-  - 10:00 to 16:00 JST (Asia/Tokyo) on 10 October 2024
+  - 10:00 to 17:00 JST (Asia/Tokyo) on 10 October 2024
 - **Location**: Tokyo, Japan
 - **Attendee information**: https://github.com/tc39/Reflector/issues/537
 


### PR DESCRIPTION
Hosts have agreed to go longer on Thursday to accommodate a packed agenda.