### PR TITLE
Add "Vision for numeric types in ECMAScript" to 2024-12 agenda

### DIFF
--- a/2024/12.md
+++ b/2024/12.md
@@ -122,6 +122,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
+    | 60m     | Vision for numeric types in ECMAScript | Shane F. Carr |
 
 1. Overflow from timeboxed agenda items (in insertion order)
 


### PR DESCRIPTION
Don't have slides yet, but wanted to add this timebox.

We can also do this in a separate session if the TG1 agenda fills up too much.

CC @ben-allen @nicolo-ribaudo @jessealama @ljharb 