### PR TITLE
Remove spurious DurationFormat PR, as it was an entirely editorial PR

### DIFF
--- a/2024/12.md
+++ b/2024/12.md
@@ -117,7 +117,6 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | stage | timebox | topic | presenter |
     |:-----:|:-------:|-------|-----------|
-    | 3     | 5m      | [Intl.DurationFormat](https://github.com/tc39/proposal-intl-duration-format) Correct spec bug resulting in fraction digits and rounding mode options being ignored. ([PR](https://github.com/tc39/proposal-intl-duration-format/pull/203/)) | Ben Allen |
     | 2.7   | 15m     | [`Error.isError`](https://github.com/tc39/proposal-is-error/issues/7) to stage 3? | Jordan Harband |
     | 2.7   | 15m     | [iterator sequencing](https://github.com/tc39/proposal-iterator-sequencing) for Stage 3 ([tests](https://github.com/tc39/test262/pull/4326)) ([slides](https://docs.google.com/presentation/d/1EHMDcnV9zJ1E7BRhKmYtzHchZvOzjWynR3W-VdNxglw)) | Michael&nbsp;Ficarra |
     | 2     | 5m      | [AsyncContext](https://github.com/tc39/proposal-async-context) request for Stage 2.7 reviewers | Andreu Botella |


### PR DESCRIPTION
This is an entirely editorial PR with one commit mismarked as normative. Does not need plenary approval.