### PR TITLE
2024.12 Add "Module harmony" slides

### DIFF
--- a/2024/12.md
+++ b/2024/12.md
@@ -137,7 +137,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | timebox | topic | presenter |
     |:-------:|-------|-----------|
-    | 45m     | Module Harmony: where we are and what we are exploring | Nicolò Ribaudo |
+    | 30m     | Module Harmony: where we are ([slides](https://docs.google.com/presentation/d/1V2-4Hj-HBVQwdphcJUsrbmbitOPBMSf3HhKSvhBk4d0/edit?usp=sharing)) | Nicolò Ribaudo |
     | 60m     | Vision for numeric types in ECMAScript ([slides](https://docs.google.com/presentation/d/1Uzrf-IwPrljF2BhCbCWuwQxlgGSm_bcd3FRbPO3Yrio/edit#slide=id.p)) | Shane F. Carr |
 
 1. Overflow from timeboxed agenda items (in insertion order)
@@ -182,3 +182,5 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 #### Late-breaking Schedule Constraints
 
 <!-- Constraints supplied less than three days before the meeting should go here -->
+
+- Not super imortant, but if there is a choice it'd be great to have the "Module harmony" presentation before the other module presentations, as it gives a very high level overview.


### PR DESCRIPTION
Apologies for adding these slides so late — they don't require any concrete feedback and they are not proposing anything normative. I mostly added the topic since I saw that the agenda had a lot of free time.

@tc39/chairs I added a scheduling _preference_ for it, but if the schedule is already done then it's fine.

cc @guybedford