### PR TITLE
Fix typo in meeting times in 02.md

### DIFF
--- a/2025/02.md
+++ b/2025/02.md
@@ -24,7 +24,7 @@ gantt
 For meeting times in your timezone, visit [Temporal docs](https://tc39.es/proposal-temporal/docs/) and run the code below in the devtools console.
 
 ```js
-Temporal.ZonedDateTime.from('2025-12-18T10:00[America/Los_Angeles]')
+Temporal.ZonedDateTime.from('2025-02-18T10:00[America/Los_Angeles]')
   .withTimeZone(Temporal.Now.timeZoneId()) // your time zone
   .toLocaleString()
 ```


### PR DESCRIPTION
meeting date in js code should be `2025-02-18`, not `2025-12-18`