### PR TITLE
add links to spec PRs for going-for-stage-4 proposals

### DIFF
--- a/2025/02.md
+++ b/2025/02.md
@@ -114,8 +114,8 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |:-----:|:-------:|-------|-----------|
     |   3   | 5m       | [Float16Array](https://github.com/tc39/proposal-float16array) for stage 4 ([spec PR](https://github.com/tc39/ecma262/pull/3532)) | Kevin Gibbons |
     |   3   | 10m      | [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) Needs Consensus PR ([PR](https://github.com/rbuckton/ecma262/pull/13)) | Ron Buckton |
-    |   3   | 15m     | [Redeclarable global eval vars](https://github.com/tc39/proposal-redeclarable-global-eval-vars) for [stage 4](https://github.com/tc39/proposal-redeclarable-global-eval-vars/issues/3) | Shu-yu Guo |
-    |   3   | 15m     | [RegExp Escaping](https://github.com/tc39/proposal-regex-escaping/issues/58) for stage 4 | Jordan Harband |
+    |   3   | 15m     | [Redeclarable global eval vars](https://github.com/tc39/proposal-redeclarable-global-eval-vars) for [stage 4](https://github.com/tc39/proposal-redeclarable-global-eval-vars/issues/3) ([spec PR](https://github.com/tc39/ecma262/pull/3226)) | Shu-yu Guo |
+    |   3   | 15m     | [RegExp Escaping](https://github.com/tc39/proposal-regex-escaping/issues/58) for stage 4 ([spec PR](https://github.com/tc39/ecma262/pull/3382)) | Jordan Harband |
     |   3   | 20m     | [Temporal](https://github.com/tc39/proposal-temporal) normative [PR](https://github.com/tc39/proposal-temporal/pull/3054) and status update ([slides](http://ptomato.name/talks/tc39-2025-02/#8)) | Philip Chimento |
     |   3   | 30m     | [Intl Locale Info API](https://github.com/tc39/proposal-intl-locale-info) Update in Stage 3 ([PR](https://github.com/tc39/ecma402/pull/942), [slide](https://docs.google.com/presentation/d/14ColNEWDFlAnPGW6GSPSk6gbcdTmSy4pYuYXOwDlZX8)) | Frank Yung-Fong Tang |
     |   3   | 30m     | [Decorators](https://github.com/tc39/proposal-decorators) implementation updates | Kristen Hewell Garrett |


### PR DESCRIPTION
"Proposals looking to advance to stage 4 must link to a pull request into [the spec](https://github.com/tc39/ecma262), since the [process](https://tc39.github.io/process-document/) requires one."

(In both cases you can find the spec PR by following a link from the linked issues, but I have always understood the requirement to link to supporting materials to mean that you must _directly_ link to them.)