### PR TITLE
2025.02: Add import defer slides

### DIFF
--- a/2025/02.md
+++ b/2025/02.md
@@ -122,7 +122,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |   3   | 30m     | [Intl Locale Info API](https://github.com/tc39/proposal-intl-locale-info) Update in Stage 3 ([PR](https://github.com/tc39/ecma402/pull/942), [slide](https://docs.google.com/presentation/d/14ColNEWDFlAnPGW6GSPSk6gbcdTmSy4pYuYXOwDlZX8)) | Frank Yung-Fong Tang |
     |   3   | 30m     | [Decorators](https://github.com/tc39/proposal-decorators) implementation updates ([slides](https://slides.com/pzuraq/decorators-for-stage-3-2022-03-977778)) | Kristen Hewell Garrett |
     |  2.7  | 10m     | [ShadowRealm](https://github.com/tc39/proposal-shadowrealm) status update ([slides](http://ptomato.name/talks/tc39-2025-02/#1)) | Philip Chimento |
-    |  2.7  | 15m     | [import defer](https://github.com/tc39/proposal-defer-import-eval/) for Stage 3 (tests: all PRs linked to https://github.com/tc39/test262/issues/4215) | Nicolò Ribaudo |
+    |  2.7  | 15m     | [import defer](https://github.com/tc39/proposal-defer-import-eval/) for Stage 3 (tests: all PRs linked to https://github.com/tc39/test262/issues/4215, [slides](https://docs.google.com/presentation/d/1LjsJhdTIP3wgo1odtVa-qbfyGU5M1W9YMm0AtKnJJKk/edit?usp=sharing)) | Nicolò Ribaudo |
     |   2   | 30m     | [Immutable ArrayBuffer](https://github.com/tc39/proposal-immutable-arraybuffer) for stage 2.7 | Mark Miller |
     |   2   | 45m     | [Records & Tuples](https://github.com/tc39/proposal-record-tuple) future directions temp checks | Ashley Claymore |
     |   1   | 30m     | [Limited ArrayBuffer](https://github.com/tc39/proposal-limited-arraybuffer) update: stay on stage 1 or withdraw?, [slides](https://docs.google.com/presentation/d/1u6JsSeInvm6F4OrmCSLubtDvFVdjw1ESeE5-c_YflHE/) | Jack Works |


### PR DESCRIPTION
I was planning on not having slides and just linking to the tests (since there are no changes to the proposal), but I got feedback that slides still are nice to have something to look at rather than screen-sharing GitHub :)