### PR TITLE
Remove Allen's standards participation guide

### DIFF
--- a/template.md
+++ b/template.md
@@ -32,10 +32,7 @@ Temporal.ZonedDateTime.from('2021-10-25T10:00[Europe/London]')
   .toLocaleString()
 ```
 
-Background:
-
-- Allen Wirfs-Brock's [paper on standards committee participation for new attendees](http://wirfs-brock.com/allen/files/papers/standpats-asianplop2016.pdf)
-- TC39's documentation on [How to participate in meetings](https://github.com/tc39/how-we-work/blob/HEAD/how-to-participate-in-meetings.md)
+TC39's documentation on [How to participate in meetings](https://github.com/tc39/how-we-work/blob/HEAD/how-to-participate-in-meetings.md)
 
 ## Agenda topic rules
 


### PR DESCRIPTION
I don't want us to tell new delegates, "Don’t Talk Too Much", which comes up very prominently and early in this document. Instead, we should encourage new delegates to talk! We can reference this document from some places, as it has interesting ideas, but only if we can frame it with that context.