### PR TITLE
2025-05: add Array.fromAsync Stage 4 and BigInt Math Stage 2

### DIFF
--- a/2025/05.md
+++ b/2025/05.md
@@ -112,7 +112,9 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | stage | timebox | topic | presenter |
     |:-----:|:-------:|-------|-----------|
+    | 4 | 30m | `Array.fromAsync` for Stage 4 ([spec pull request](https://github.com/tc39/ecma262/pull/3581)) | J. S. Choi |
     | 2.7 | 60m | [Immutable ArrayBuffer](https://github.com/tc39/proposal-immutable-arraybuffer) for stage 3 (slides coming)  | Mark Miller, Peter Hoddie |
+    | 1 | 30m | [BigInt Math](https://github.com/tc39/proposal-bigint-math/) for Stage 2 | J. S. Choi |
 
 1. Longer or open-ended discussions
 
@@ -143,6 +145,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
 <!-- Constraints supplied more than three days before the meeting should go here -->
 - Samina would prefer the "ECMA Framework" topic to be discussed on Day 2 to give people time to mull it over and bring any questions or doubts the following day.
+- J. S. Choi is unavailable until 15:00 (GMT+2) on all days and would strongly prefer 05-28 or 05-29 over 05-30.
 
 #### Late-breaking Schedule Constraints
 


### PR DESCRIPTION
Please note that the proposal-array-from-async proposal is out of date and still has a pending pull request (tc39/proposal-array-from-async#50). 

The most up-to-date version is the tc39/ecma262#3581 pull request linked in the table.