### PR TITLE
2025.05: remove upsert

### DIFF
--- a/2025/05.md
+++ b/2025/05.md
@@ -123,7 +123,6 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | 3 | 20m | [Temporal](https://github.com/tc39/proposal-temporal) status update and normative change ([slides](https://ptomato.name/talks/tc39-2025-05/)) | Philip Chimento |
     | 3 | 30m | [`Array.fromAsync`](https://github.com/tc39/proposal-array-from-async) for Stage 4 ([spec pull request](https://github.com/tc39/ecma262/pull/3581), [slides](https://docs.google.com/presentation/d/1i100S94niIcnBj9yhm4l0R9-6hCUbjGMi8tzqkGI2RM/edit?usp=sharing)) | J. S. Choi |
     | 2.7 | 30m | [Immutable ArrayBuffer](https://github.com/tc39/proposal-immutable-arraybuffer) for stage 3 (slides coming)  | Peter Hoddie, Richard Gibson |
-    | 2.7 | 30m | [Upsert](https://github.com/tc39/proposal-upsert) for stage 3 ([slides](https://docs.google.com/presentation/d/15J_tgYqrh-aPat0klS78BcDVGYJ88HOCC_SBsYkR4QY/))  | Daniel Minor |
     | 2.7 | 30m | [Iterator Sequencing](https://github.com/tc39/proposal-iterator-sequencing) for Stage 3 ([slides](https://docs.google.com/presentation/d/1XXAqt72dHIBQBvTRmR4UqOWbEcj_zqoS61NRMwriJ7s)) | Michael Ficarra |
     | 2 | 30m | [Iterator Chunking](https://github.com/tc39/proposal-iterator-chunking) for Stage 2.7 ([slides](https://docs.google.com/presentation/d/1Mse7PDM0vcMg4Ag_SK1_OGwVwrJuVxKz-qaWj2RyX8o)) | Michael Ficarra |
     | 2 | 60m | [AsyncContext](github.com/tc39/proposal-async-context/) web integration brainstorming ([slides](https://docs.google.com/presentation/d/1yBtSvF5z3P4PliB2NziYzm90d27keiX2P9-MfoDvpJs/edit?usp=sharing)) | Andreu Botella |


### PR DESCRIPTION
There won't be time to fully merge the upsert tests from staging, I'll plan to present this item at the next plenary.