### PR TITLE
2025.05: Add discussion moving TCQ forward

### DIFF
--- a/2025/05.md
+++ b/2025/05.md
@@ -112,6 +112,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |:-------:|-------|-----------|
     | 30m     | Proposed change to the agenda deadline | Chris de Almeida |
     | 30m     | Maintaining Proposal Topics ([slides](https://docs.google.com/presentation/d/1jWTwZ91AbZvS8OYwDzmNdG4CmN20oyBn9qPHd3FmOQI/edit?usp=sharing)) | Mikhail Barash, J. S. Choi, Michael Ficarra |
+    | 30m     | Moving TCQ forward ([repo](https://github.com/zalari/tcq/tree/contemporary-edition)) | Christian Ulbrich |
 
 1. Proposals
 


### PR DESCRIPTION
I'd like to discuss moving TCQ forward. I did all the [groundwork](https://github.com/zalari/tcq/tree/contemporary-edition) to _de-couple_ TCQ from existing (M$) infrastructure and get it going `as-is` on _any_ infrastructure by adding very shallow _adapters_ to accommodate for "somebody else computer" (aka Cloud).

I had it deployed on AWS + hosted MongoDB and I'll have it running by Friday, hopefully **today** (2025-28) in the afternoon today again.

I'd like to get feedback and the actions that need to be done, to get this thing into a state, where everyone can:
* deploy / restart aka _manage_ TCQ
* ...we can have a _managed_ repo, that allows us to add features
* ...how we want to actually move it forward (re-write)...

Currently it is not a re-write in any way, it just allows us to run TCQ and well... let's discuss things on Friday then!