### PR TITLE
2025.07: Add keep-trailing-zeros slides and add Amount for Stage 2

### DIFF
--- a/2025/07.md
+++ b/2025/07.md
@@ -130,9 +130,10 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | 2 | 45m | [Intl Era and Month Code](https://github.com/tc39/proposal-intl-era-monthcode) for Stage 2.7 ([slides](https://docs.google.com/presentation/d/1dAbacNvhPL_iUJKZNPDbQVyfg8a6-OHUuh2OiftMu1A/edit?slide=id.p#slide=id.p)) | Ujjwal Sharma |
     | 2 | 5m | [AsyncContext](https://github.com/tc39/proposal-async-context/) update | Andreu Botella |
     | 1 | 30m | [Error.captureStackTrace](https://github.com/tc39/proposal-error-capturestacktrace) for Stage 2 ([slides](https://docs.google.com/presentation/d/1RGNDcJee_6N2II0SeGyMVglvjhJbuqDX02LLzBqyCWI/)) | Daniel Minor |
-    | 1 | 30m | [Keep trailing zeros in Intl.NumberFormat and Intl.PluralRules](https://github.com/eemeli/proposal-intl-keep-trailing-zeros) for Stage 2 or 2.7 (slides TBD) | Eemeli Aro |
+    | 1 | 30m | [Keep trailing zeros in Intl.NumberFormat and Intl.PluralRules](https://github.com/tc39/proposal-intl-keep-trailing-zeros) for Stage 2 or 2.7 ([slides](https://docs.google.com/presentation/d/1hKJFrDfiGeqPWm51fQFQb4M4CeYm3ultB7Opef1BVuE/edit?usp=sharing)) | Eemeli Aro |
     | 0 | 30m | [Import Buffer](https://github.com/styfle/proposal-import-buffer) for Stage 1 ([slides](https://proposal-import-buffer.vercel.app)) | Steven Salat |
     | 1 | 30m | [Object.propertyCount](https://github.com/tc39/proposal-object-property-count) for Stage 2 (slides TBD) | @BridgeAR |
+    | 1 | 60m | [~~Measure~~Amount](https://github.com/tc39/proposal-measure) for Stage 2 ([slides](https://docs.google.com/presentation/d/1my6X1ODDckzJmtcWcFI9hRF_I06Z4RQwrq81lbo8wPM/edit?usp=sharing)) | Eemeli Aro/Jesse Alama |
     | 0 | 30m | [Array.isSparse](https://github.com/BridgeAR/isSparse) for Stage 1 (slides TBD) | @BridgeAR |
     | 0 | 30m | [Array.getNonIndexStringProperties](https://github.com/BridgeAR/array-get-non-index-string-properties) for Stage 1 (slides TBD) | @BridgeAR |
     | 0 | 30m | [Object.getOwnPropertySymbols options](https://github.com/BridgeAR/object-get-own-property-symbols-options) for Stage 1 (slides TBD) | @BridgeAR |
@@ -167,7 +168,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
 <!-- Constraints supplied more than three days before the meeting should go here -->
 - Eemeli will be available on Day 1 from 11:30 onwards, and will not be available on Day 4.
-  He would prefer to present on keep-trailing-zeros before any other numerics presentations.
+  He would prefer to present on keep-trailing-zeros before the Measure/Amount presentation.
 - Ruben will be able to attend one day only. It is not important which one.
   He would prefer to present all four proposals in one go, especially, since they are all somewhat related to each other.
 


### PR DESCRIPTION
I also noticed that the Import Buffer item appears to have been added in the wrong place in the agenda, but didn't touch it.