### PR TITLE
Non-ext-applies-to-private needs to be after monday

### DIFF
--- a/2025/07.md
+++ b/2025/07.md
@@ -127,7 +127,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | 2.7 | 15m | [Iterator Sequencing](https://github.com/tc39/proposal-iterator-sequencing) for Stage 3 ([slides](https://docs.google.com/presentation/d/12zBgwq7qSpf-GXySU0q6t46vTdYAyFxaKW26J8D5IiE)) | Michael Ficarra |
     | 2.7 | 15m | [Upsert](https://github.com/tc39/proposal-upsert) for Stage 3 ([slides](https://docs.google.com/presentation/d/15J_tgYqrh-aPat0klS78BcDVGYJ88HOCC_SBsYkR4QY/)) | Daniel Minor |
     | 2.7 | 30m | [Immutable ArrayBuffer](https://github.com/tc39/proposal-immutable-arraybuffer) for stage 3 ([slides](https://docs.google.com/presentation/d/18JnyoJsovfw7Y_HGa0cZOOUCHY2MTO4_M72zKj7PUWo/edit?usp=sharing)) | Richard Gibson, Peter Hoddie |
-    | 2.7 | 30m | [Non-extensible Applies to Private](https://github.com/tc39/proposal-nonextensible-applies-to-private) for stage 3 (slides TBD) | Mark Miller |
+    | 2.7 | 30m | [Non-extensible Applies to Private](https://github.com/tc39/proposal-nonextensible-applies-to-private) status update  (slides TBD) | Mark Miller |
     | 2 | 30m | [Iterator Chunking](https://github.com/tc39/proposal-iterator-chunking) for Stage 2.7 ([slides](https://docs.google.com/presentation/d/17qDtY-2Qawt7SeKoY7Rezea-A_hAuwhx2QHJ9MCZ7as)) | Michael Ficarra |
     | 2 | 45m | [Intl Era and Month Code](https://github.com/tc39/proposal-intl-era-monthcode) for Stage 2.7 ([slides](https://docs.google.com/presentation/d/1dAbacNvhPL_iUJKZNPDbQVyfg8a6-OHUuh2OiftMu1A/edit?slide=id.p#slide=id.p)) | Ujjwal Sharma |
     | 2 | 5m | [AsyncContext](https://github.com/tc39/proposal-async-context/) web integration update ([slides](https://docs.google.com/presentation/d/1d64udRyuYplXajTCMQkGrVh2jff464_7D75dZ6pSxiE/edit?usp=sharing)) | Andreu Botella |
@@ -178,3 +178,4 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 #### Late-breaking Schedule Constraints
 
 <!-- Constraints supplied less than three days before the meeting should go here -->
+- Mark Miller will not be ready to present [Non-extensible Applies to Private](https://github.com/tc39/proposal-nonextensible-applies-to-private) on Monday. Any other day is fine.


### PR DESCRIPTION
[Non-extensible Applies to Private](https://github.com/tc39/proposal-nonextensible-applies-to-private) needs to be after monday. I'm also changing it from "for stage 3" to "status update"