### PR TITLE
change import bytes proposal to stage 2 in 2025-07 agenda

### DIFF
--- a/2025/07.md
+++ b/2025/07.md
@@ -135,7 +135,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | 1 | 30m | [Keep trailing zeros in Intl.NumberFormat and Intl.PluralRules](https://github.com/tc39/proposal-intl-keep-trailing-zeros) for Stage 2 or 2.7 ([slides](https://docs.google.com/presentation/d/1hKJFrDfiGeqPWm51fQFQb4M4CeYm3ultB7Opef1BVuE/edit?usp=sharing)) | Eemeli Aro |
     | 1 | 30m | [Object.propertyCount](https://github.com/tc39/proposal-object-property-count) for Stage 2 (slides TBD) | Ruben Bridgewater |
     | 1 | 60m | [~~Measure~~Amount](https://github.com/tc39/proposal-measure) for Stage 2 ([slides](https://docs.google.com/presentation/d/1my6X1ODDckzJmtcWcFI9hRF_I06Z4RQwrq81lbo8wPM/edit?usp=sharing)) | Eemeli Aro/Jesse Alama |
-    | 0 | 30m | [Import Buffer](https://github.com/styfle/proposal-import-buffer) for Stage 1 ([slides](https://proposal-import-buffer.vercel.app)) | Steven Salat |
+    | 0 | 30m | [Import Buffer](https://github.com/styfle/proposal-import-buffer) for Stage 1, or :hourglass: 2 ([slides](https://proposal-import-buffer.vercel.app)) | Steven Salat |
     | 0 | 30m | [Array.isSparse](https://github.com/BridgeAR/isSparse) for Stage 1 (slides TBD) | Ruben Bridgewater |
     | 0 | 30m | [Array.getNonIndexStringProperties](https://github.com/BridgeAR/array-get-non-index-string-properties) for Stage 1 (slides TBD) | Ruben Bridgewater |
     | 0 | 30m | [Object.getOwnPropertySymbols options](https://github.com/BridgeAR/object-get-own-property-symbols-options) for Stage 1 (slides TBD) | Ruben Bridgewater |


### PR DESCRIPTION
I was speaking to Guy who said its possible to go from Stage 0 to Stage 2, thereby skipping Stage 1.

> it could be possible but you’d need to post a PR to the agenda to note possible stage 2 request. When asking we would then have to make it very clear that this can be rejected by anyone without any concern on the grounds of the late spec.

- Related to https://github.com/styfle/proposal-import-buffer/pull/10
