### PR TITLE
add item for strings-as-enums are kebab-case

### DIFF
--- a/2025/09.md
+++ b/2025/09.md
@@ -100,6 +100,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |:-------:|-------|-----------|
     | 10m     | [Normative: Add `[[CompactDisplay]]` slot to Intl.PluralRules](https://github.com/tc39/ecma402/pull/1019) (slides TBD) | Ben Allen |
     | 10m     | [Normative: Make Intl.PluralRules ResolvePlural and associated AOs take Intl mathematical values rather than Numbers](https://github.com/tc39/ecma402/pull/1026) (slides TBD) | Ben Allen |
+    | 10m     | [Convention: strings-as-enums are kebab-case](https://github.com/tc39/how-we-work/pull/165) ([PR](https://github.com/tc39/how-we-work/pull/165) to normative-conventions.md) | Kevin Gibbons |
     | 30m     | [Adopt native promises](https://github.com/tc39/ecma262/pull/3689) without then (slides TBD) | Mathieu Hofman |
     | 60m     | [Increase limits on Intl MV](https://github.com/tc39/ecma402/pull/1022) with discussion of how and when to set bounds in the spec (slides TBD; see TG3 discussion) | Shane F Carr |
 


### PR DESCRIPTION
Bit late but since this is only documenting an existing convention I hope it's OK.