### PR TITLE
2025-09: spin-off promise adoption into proposal

### DIFF
--- a/2025/09.md
+++ b/2025/09.md
@@ -100,7 +100,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     |:-------:|-------|-----------|
     | 10m     | [Normative: Add `[[CompactDisplay]]` slot to Intl.PluralRules](https://github.com/tc39/ecma402/pull/1019) ([slides](https://notes.igalia.com/p/tg1-normative-PR-1019-sept-2025.md#/)) | Ben Allen |
     | 10m     | [Normative: Make Intl.PluralRules ResolvePlural and associated AOs take Intl mathematical values rather than Numbers](https://github.com/tc39/ecma402/pull/1026) ([slides](https://notes.igalia.com/p/tg1-normative-PR-1026-sept-2025.md#/)) | Ben Allen |
-    | 30m     | [Adopt native promises](https://github.com/tc39/ecma262/pull/3689) without then (slides TBD) | Mathieu Hofman |
+    | 20m     | [Normative: change PromiseResolve species check](https://github.com/tc39/ecma262/pull/3689) (slides TBD) | Mathieu Hofman |
     | 30m     | [Convention: strings-as-enums are kebab-case](https://github.com/tc39/how-we-work/pull/165) ([PR](https://github.com/tc39/how-we-work/pull/165) to normative-conventions.md) | Kevin Gibbons |
     | 60m     | [Increase limits on Intl MV](https://github.com/tc39/ecma402/pull/1022) with discussion of how and when to set bounds in the spec (slides TBD; see TG3 discussion) | Shane F Carr |
 
@@ -129,6 +129,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
     | 1     | 30m     | [Amount](https://github.com/tc39/proposal-amount) for Stage 2 ([slides](https://docs.google.com/presentation/d/1cDQBcMzSAht9jZiuaMKAEIDlPmlSmjeBJ-sw23AySWI/edit?slide=id.g37deebb6a10_2_54#slide=id.g37deebb6a10_2_54)) | Ben Allen |
     | 0     | 20m     | [Native Promise Predicate](https://github.com/mhofman/proposal-native-promise-predicate) for stage 1 or 2 [[spec](https://mhofman.github.io/proposal-native-promise-predicate/), Slides TBD] | Mathieu Hofman |
     | 0     | 20m     | [`Array.prototype.pushAll`](https://github.com/DanielRosenwasser/proposal-array-push-all/) for Stage 1 ([slides](https://danielrosenwasser.github.io/tc39-slides-2025-09-array-push-all)) | Daniel Rosenwasser |
+    | 0     | 30m     | [Native Promise Adoption](https://github.com/mhofman/proposal-native-promise-adoption) for stage 1 [[spec](https://mhofman.github.io/proposal-native-promise-adoption/), Slides TBD] | Mathieu Hofman |
 
 1. Longer or open-ended discussions
 
@@ -160,7 +161,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
 <!-- Constraints supplied more than three days before the meeting should go here -->
 - MF is only able to attend this meeting for the first 4 hours of Monday, the 22nd (I know, I'm sorry). If iterator chunking cannot be presented in that limited time range, KG will act as backup presenter.
-- MAH would like to present "Adopt native promises" before "Promise.isPromise". Collocated might make sense but not necessary.
+- MAH would like to present promise related topics in the following order: "change PromiseResolve species check", "Native Promise Adoption", and "Native Promise Predicate". Collocated might make sense but not necessary.
 - KKL would like to present "Update on proposal-module-global” in an afternoon session. If necessary and with forewarning, KKL can present at 11am Chicago at the earliest any day except Monday.
 - Philip Chimento: I would prefer not to present on Monday 22nd, but I can do it if really needed.
 - SFC would like to be present for "Increase limits on Intl MV", "Amount for Stage 2", "Temporal update", and Ben Allen's two ECMA-402 PRs. SFC is *not* available from 13:00-15:00 on Monday, 10:00-13:30 on Tuesday, 12:30-13:30 on Wednesday, and 10:00-12:00 on Thursday (all times in CDT). He is available 10:00-12:30 on Wednesday but prefers to not be the presenter (of "Increase limits on Intl MV") at that time.


### PR DESCRIPTION
I was asked to separate the promise adoption part of https://github.com/tc39/ecma262/pull/3689 into its own proposal and reduce the scope of the normative PR to only the `PromiseResolve` part. This does that, and requests for more time overall expecting the promise adoption topic to be more contentious than expected.

To be clear: this does not introduce any new material. All significant content of the new promise adoption proposal was directly extracted from the normative PR.