### PR TITLE
Add "estimated meeting capacity" to the template

### DIFF
--- a/template.md
+++ b/template.md
@@ -10,6 +10,7 @@
 - **Location**: CITY, COUNTRY
 - **Attendee information**: LINK TO REFLECTOR
 - **Total duration of scheduled discussions**: ![dynamically computed total of timeboxes on the agenda](https://tc39-agenda-time.deno.dev/YYYY/MM/) <!-- UPDATE YYYY AND MM -->
+  - **Estimated meeting capacity**: CHOOSE ONE <!-- in person: 17:00h ; remote: 16:00h -- this is computed subtracting 100min per day for in-person meetings, and 60min per day for remote meetings --> <sub>This is an <em>estimate</em>: if you want to add a topic to the agenda, do not let this number stop you!</sub>
 
 ```mermaid
 gantt

--- a/template.md
+++ b/template.md
@@ -10,7 +10,7 @@
 - **Location**: CITY, COUNTRY
 - **Attendee information**: LINK TO REFLECTOR
 - **Total duration of scheduled discussions**: ![dynamically computed total of timeboxes on the agenda](https://tc39-agenda-time.deno.dev/YYYY/MM/) <!-- UPDATE YYYY AND MM -->
-  - **Estimated meeting capacity**: CHOOSE ONE <!-- in person: 17:00h ; remote: 16:00h -- this is computed subtracting 100min per day for in-person meetings, and 60min per day for remote meetings --> <sub>This is an <em>estimate</em>: if you want to add a topic to the agenda, do not let this number stop you!</sub>
+  - **Estimated meeting capacity**: CHOOSE ONE <!-- in person: 15:00h ; remote: 16:00h -- this is computed subtracting 100min per day for in-person meetings, and 60min per day for remote meetings --> <sub>This is an <em>estimate</em>: if you want to add a topic to the agenda, do not let this number stop you!</sub>
 
 ```mermaid
 gantt


### PR DESCRIPTION
From @ctcpip:

> generally speaking it is safest to say: (end-start)-100 minutes
> that's for hybrid meetings.  remote-only meetings are consistently (end-start)-60 minutes

It's helpful so that I can look at how many topics there are in the agenda, and decide if I need to try to anticipate something that I was planning to present at the meeting after, or if I do not need to rush preparing multiple topics because the meeting is likely to overflow anyway.