### PR TITLE
26-07: Add await dictionary for stage 3

### DIFF
--- a/2026/07.md
+++ b/2026/07.md
@@ -117,6 +117,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 
     | stage | timebox | topic | presenter |
     |:-----:|:-------:|-------|-----------|
+    | 2.7 | 30m | [Await Dictionary](https://github.com/tc39/proposal-await-dictionary) for Stage 3 ([spec](https://tc39.es/proposal-await-dictionary/), tests: [1](https://github.com/tc39/test262/tree/main/test/built-ins/Promise/allKeyed), [2](https://github.com/tc39/test262/tree/main/test/built-ins/Promise/allSettledKeyed)) | Ashley Claymore |
     | 2 | 30m | [Thenable Curtailment](https://github.com/tc39/proposal-thenable-curtailment) for 2.7 ([slides (in progress)](https://docs.google.com/presentation/d/1kHq_UqMHGGT8ena8yMlJKgHmohDVqxJvV4hiCB12HtU/view?)) | Matthew Gaudet |
     | 2 | 60m | [Async iterator helpers](https://github.com/tc39/proposal-async-iterator-helpers) open questions ([slides](https://docs.google.com/presentation/d/17_mL3guxupbKWKr1EbDdML9K9kPTqElbf9xgoZZDBh0/edit)) and [demo](https://bakkot.github.io/async-iterator-helpers-implementation/) | Kevin Gibbons |
     | 1 | 20m | [Error code property](https://github.com/tc39/proposal-error-code-property) for Stage 2 or 2.7 | James Snell |


### PR DESCRIPTION
Spec: https://tc39.es/proposal-await-dictionary/

Tests: https://github.com/tc39/test262/tree/main/test/built-ins/Promise/allKeyed https://github.com/tc39/test262/tree/main/test/built-ins/Promise/allSettledKeyed