### PR TITLE
add GitHub Action to check proposal agenda item ordering

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -11,10 +11,11 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
+      - run: npm run lint
       - run: npm test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: 'Lint Markdown'
+name: 'Lint and Test'
 
 on:
   push:
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
-      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
       - run: npm test

--- a/.github/workflows/proposals-order.yml
+++ b/.github/workflows/proposals-order.yml
@@ -1,0 +1,24 @@
+name: 'Check proposals table order'
+
+on:
+  pull_request:
+    paths:
+      - '[0-9][0-9][0-9][0-9]/[0-9][0-9].md'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          #  full history so the script can diff against the fork point,
+          #  however far back the PR branched
+          fetch-depth: 0
+      - uses: ljharb/actions/node/install@main
+        name: 'nvm install lts/* && npm install'
+      - run: node ./scripts/check-proposals-order.mjs --base "$BASE_SHA"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/proposals-order.yml
+++ b/.github/workflows/proposals-order.yml
@@ -19,6 +19,6 @@ jobs:
           fetch-depth: 0
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
-      - run: node ./scripts/check-proposals-order.mjs --base "$BASE_SHA"
+      - run: npm run check-proposals-order -- --base "$BASE_SHA"
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "check-proposals-order": "node ./scripts/check-proposals-order.cli.mjs",
     "lint": "markdownlint-cli2",
     "lint:fix": "markdownlint-cli2 --fix",
-    "test": "npm run lint && npm run test:unit",
+    "pretest": "npm run lint",
+    "test": "npm run test:unit",
     "test:unit": "node --test 'scripts/*.test.mjs'"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "a2s": "node ./scripts/agenda-to-schedule.mjs",
     "build": "./scripts/generate.js",
-    "check-proposals-order": "node ./scripts/check-proposals-order.mjs",
+    "check-proposals-order": "node ./scripts/check-proposals-order.cli.mjs",
     "lint": "markdownlint-cli2",
     "lint:fix": "markdownlint-cli2 --fix",
     "test": "npm run lint && npm run test:unit",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "scripts": {
     "a2s": "node ./scripts/agenda-to-schedule.mjs",
     "build": "./scripts/generate.js",
+    "check-proposals-order": "node ./scripts/check-proposals-order.mjs",
     "lint": "markdownlint-cli2",
     "lint:fix": "markdownlint-cli2 --fix",
-    "test": "npm run lint"
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "node --test 'scripts/*.test.mjs'"
   },
   "devDependencies": {
     "dedent": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "check-proposals-order": "node ./scripts/check-proposals-order.cli.mjs",
     "lint": "markdownlint-cli2",
     "lint:fix": "markdownlint-cli2 --fix",
-    "pretest": "npm run lint",
     "test": "npm run test:unit",
     "test:unit": "node --test 'scripts/*.test.mjs'"
   },

--- a/scripts/check-proposals-order.cli.mjs
+++ b/scripts/check-proposals-order.cli.mjs
@@ -51,7 +51,10 @@ const SEVERITY = {
 const RUN_FAILURE_KINDS = new Set(['missing-table']);
 
 function git(...args) {
-  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
 }
 
 function tryGitShow(commit, file) {
@@ -79,14 +82,23 @@ function escapeAnnotationProperty(text) {
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
     switch (argv[i]) {
-      case '--base': options.base = argv[++i]; break;
-      case '--head': options.head = argv[++i]; break;
-      case '--strict': options.strict = true; break;
-      default: options.files.push(argv[i]);
+      case '--base':
+        options.base = argv[++i];
+        break;
+      case '--head':
+        options.head = argv[++i];
+        break;
+      case '--strict':
+        options.strict = true;
+        break;
+      default:
+        options.files.push(argv[i]);
     }
   }
   if (options.base == null) {
-    console.error('Usage: npm run check-proposals-order -- --base <ref> [--head <ref>] [--strict] [files...]');
+    console.error(
+      'Usage: npm run check-proposals-order -- --base <ref> [--head <ref>] [--strict] [files...]',
+    );
     process.exitCode = 2;
     return;
   }
@@ -113,9 +125,17 @@ function escapeAnnotationProperty(text) {
 
   let files = options.files;
   if (files.length === 0) {
-    const diffArgs = ['diff', '--name-only', '--diff-filter=ACMR', '--no-renames', base];
+    const diffArgs = [
+      'diff',
+      '--name-only',
+      '--diff-filter=ACMR',
+      '--no-renames',
+      base,
+    ];
     if (options.head != null) diffArgs.push(options.head);
-    files = git(...diffArgs).split('\n').filter(file => AGENDA_PATH_PATTERN.test(file));
+    files = git(...diffArgs)
+      .split('\n')
+      .filter((file) => AGENDA_PATH_PATTERN.test(file));
   }
   if (files.length === 0) {
     console.error('No agenda documents changed.');
@@ -147,19 +167,28 @@ function escapeAnnotationProperty(text) {
     for (const { kind, line, message } of annotations) {
       if (RUN_FAILURE_KINDS.has(kind)) runFailed = true;
       else if (SEVERITY[kind] === 'error') errorCount++;
-      const title = RUN_FAILURE_KINDS.has(kind) ? 'Proposals table not found' : 'Proposals table ordering';
+      const title = RUN_FAILURE_KINDS.has(kind)
+        ? 'Proposals table not found'
+        : 'Proposals table ordering';
       // a run-failure annotation has no row to anchor to, so it is file-level
-      const location = line == null
-        ? `file=${escapeAnnotationProperty(file)}`
-        : `file=${escapeAnnotationProperty(file)},line=${line}`;
-      console.log(`::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`);
+      const location =
+        line == null
+          ? `file=${escapeAnnotationProperty(file)}`
+          : `file=${escapeAnnotationProperty(file)},line=${line}`;
+      console.log(
+        `::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`,
+      );
     }
     if (annotations.length === 0) {
       console.error(`OK: ${file}`);
-    } else if (annotations.some(annotation => RUN_FAILURE_KINDS.has(annotation.kind))) {
+    } else if (
+      annotations.some((annotation) => RUN_FAILURE_KINDS.has(annotation.kind))
+    ) {
       console.error(`Could not check ${file}: no proposals table found.`);
     } else {
-      console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
+      console.error(
+        `${annotations.length} ordering problem(s) introduced in ${file}`,
+      );
     }
   }
   // a failure to run takes precedence over ordering violations

--- a/scripts/check-proposals-order.cli.mjs
+++ b/scripts/check-proposals-order.cli.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+// Entry point for the check-proposals-order npm script. Runs the checker over
+// the agenda documents changed between a base commit and the working tree (or
+// a given head), reporting problems as GitHub workflow-command annotations
+// (::error / ::warning) that render inline on the PR diff. The checking logic
+// lives in check-proposals-order.mjs.
+//
+// Usage: npm run check-proposals-order -- --base <ref> [--head <ref>] [--strict] [files...]
+//   --base    base branch commit; the comparison point is `git merge-base
+//             <base> <head>`, i.e. the fork point
+//   --head    commit whose file contents to check; defaults to the working tree
+//   --strict  exit 1 if any error-severity ordering problem is found
+//   files     repo-relative agenda paths; defaults to the agenda documents
+//             changed between base and head
+//
+// Example: npm run check-proposals-order -- --base origin/main
+//
+// Exit codes:
+//   0  ran cleanly, or found only advisory ordering problems
+//   1  found error-severity ordering problems and --strict was passed
+//   2  could not run: bad usage, an unresolvable ref, an unreadable file, or
+//      a changed agenda document with no proposals table to check
+// Ordering problems do not fail the check by default so that we can gain
+// confidence in the absence of false positives before passing --strict to
+// block merging. A missing proposals table is not an ordering problem but a
+// failure to run — the table was renamed, moved, or its structure drifted
+// enough to break matching — so it always exits non-zero, --strict or not.
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+
+import { checkFile } from './check-proposals-order.mjs';
+
+const AGENDA_PATH_PATTERN = /^\d{4}\/\d{2}\.md$/;
+
+// annotation severity per problem kind. For ordering violations this is
+// presentational, since they only fail CI under --strict; reordering rows of
+// equal stage and timebox may be a deliberate correction of a past mistake,
+// which the check cannot distinguish, so it only warrants a warning.
+const SEVERITY = {
+  stage: 'error',
+  timebox: 'error',
+  insertion: 'error',
+  reorder: 'warning',
+  'missing-table': 'error',
+};
+
+// kinds that mean the check could not run against a file rather than that it
+// found a violation; these fail the run unconditionally, even without --strict
+const RUN_FAILURE_KINDS = new Set(['missing-table']);
+
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function tryGitShow(commit, file) {
+  try {
+    return git('show', `${commit}:${file}`);
+  } catch {
+    return null;
+  }
+}
+
+// per https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+function escapeAnnotationData(text) {
+  return text.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function escapeAnnotationProperty(text) {
+  return escapeAnnotationData(text).replace(/:/g, '%3A').replace(/,/g, '%2C');
+}
+
+const options = { base: null, head: null, strict: false, files: [] };
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  switch (argv[i]) {
+    case '--base': options.base = argv[++i]; break;
+    case '--head': options.head = argv[++i]; break;
+    case '--strict': options.strict = true; break;
+    default: options.files.push(argv[i]);
+  }
+}
+if (options.base == null) {
+  console.error('Usage: npm run check-proposals-order -- --base <ref> [--head <ref>] [--strict] [files...]');
+  process.exit(2);
+}
+
+// run from the repo root so annotation paths are repo-relative
+process.chdir(git('rev-parse', '--show-toplevel').trim());
+
+let base;
+try {
+  base = git('rev-parse', '--verify', `${options.base}^{commit}`).trim();
+} catch {
+  console.error(`Cannot resolve base ref '${options.base}'.`);
+  process.exit(2);
+}
+const head = options.head ?? 'HEAD'; // file contents still come from the working tree when --head is omitted
+// compare against the fork point, so that changes merged to the base branch
+// after this branch diverged are not attributed to it
+try {
+  base = git('merge-base', base, head).trim();
+} catch {
+  // e.g. shallow history; fall back to the base ref itself
+}
+
+let files = options.files;
+if (files.length === 0) {
+  const diffArgs = ['diff', '--name-only', '--diff-filter=ACMR', '--no-renames', base];
+  if (options.head != null) diffArgs.push(options.head);
+  files = git(...diffArgs).split('\n').filter(file => AGENDA_PATH_PATTERN.test(file));
+}
+if (files.length === 0) {
+  console.error('No agenda documents changed.');
+  process.exit(0);
+}
+
+let errorCount = 0;
+let runFailed = false;
+for (const file of files) {
+  const baseContents = tryGitShow(base, file);
+  let headContents;
+  if (options.head == null) {
+    try {
+      headContents = fs.readFileSync(file, 'utf8');
+    } catch {
+      console.error(`Cannot read '${file}' from the working tree.`);
+      process.exit(2);
+    }
+  } else {
+    headContents = tryGitShow(options.head, file);
+    if (headContents == null) {
+      console.error(`Cannot read '${file}' from '${options.head}'.`);
+      process.exit(2);
+    }
+  }
+  const annotations = checkFile(baseContents, headContents);
+  for (const { kind, line, message } of annotations) {
+    if (RUN_FAILURE_KINDS.has(kind)) runFailed = true;
+    else if (SEVERITY[kind] === 'error') errorCount++;
+    const title = RUN_FAILURE_KINDS.has(kind) ? 'Proposals table not found' : 'Proposals table ordering';
+    // a run-failure annotation has no row to anchor to, so it is file-level
+    const location = line == null
+      ? `file=${escapeAnnotationProperty(file)}`
+      : `file=${escapeAnnotationProperty(file)},line=${line}`;
+    console.log(`::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`);
+  }
+  if (annotations.length === 0) {
+    console.error(`OK: ${file}`);
+  } else if (annotations.some(annotation => RUN_FAILURE_KINDS.has(annotation.kind))) {
+    console.error(`Could not check ${file}: no proposals table found.`);
+  } else {
+    console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
+  }
+}
+// a failure to run takes precedence over ordering violations
+if (runFailed) process.exit(2);
+if (options.strict && errorCount > 0) process.exit(1);

--- a/scripts/check-proposals-order.cli.mjs
+++ b/scripts/check-proposals-order.cli.mjs
@@ -29,6 +29,7 @@
 
 import { execFileSync } from 'child_process';
 import fs from 'fs';
+import { parseArgs } from 'util';
 
 import { checkFile } from './check-proposals-order.mjs';
 
@@ -78,22 +79,20 @@ function escapeAnnotationProperty(text) {
 // setting the code rather than calling process.exit lets buffered annotation
 // output flush before the process ends (it can be truncated otherwise in CI)
 (() => {
-  const options = { base: null, head: null, strict: false, files: [] };
-  const argv = process.argv.slice(2);
-  for (let i = 0; i < argv.length; i++) {
-    switch (argv[i]) {
-      case '--base':
-        options.base = argv[++i];
-        break;
-      case '--head':
-        options.head = argv[++i];
-        break;
-      case '--strict':
-        options.strict = true;
-        break;
-      default:
-        options.files.push(argv[i]);
-    }
+  let options, positionals;
+  try {
+    ({ values: options, positionals } = parseArgs({
+      options: {
+        base: { type: 'string' },
+        head: { type: 'string' },
+        strict: { type: 'boolean', default: false },
+      },
+      allowPositionals: true,
+    }));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 2;
+    return;
   }
   if (options.base == null) {
     console.error(
@@ -123,7 +122,7 @@ function escapeAnnotationProperty(text) {
     // e.g. shallow history; fall back to the base ref itself
   }
 
-  let files = options.files;
+  let files = positionals;
   if (files.length === 0) {
     const diffArgs = [
       'diff',

--- a/scripts/check-proposals-order.cli.mjs
+++ b/scripts/check-proposals-order.cli.mjs
@@ -71,89 +71,101 @@ function escapeAnnotationProperty(text) {
   return escapeAnnotationData(text).replace(/:/g, '%3A').replace(/,/g, '%2C');
 }
 
-const options = { base: null, head: null, strict: false, files: [] };
-const argv = process.argv.slice(2);
-for (let i = 0; i < argv.length; i++) {
-  switch (argv[i]) {
-    case '--base': options.base = argv[++i]; break;
-    case '--head': options.head = argv[++i]; break;
-    case '--strict': options.strict = true; break;
-    default: options.files.push(argv[i]);
-  }
-}
-if (options.base == null) {
-  console.error('Usage: npm run check-proposals-order -- --base <ref> [--head <ref>] [--strict] [files...]');
-  process.exit(2);
-}
-
-// run from the repo root so annotation paths are repo-relative
-process.chdir(git('rev-parse', '--show-toplevel').trim());
-
-let base;
-try {
-  base = git('rev-parse', '--verify', `${options.base}^{commit}`).trim();
-} catch {
-  console.error(`Cannot resolve base ref '${options.base}'.`);
-  process.exit(2);
-}
-const head = options.head ?? 'HEAD'; // file contents still come from the working tree when --head is omitted
-// compare against the fork point, so that changes merged to the base branch
-// after this branch diverged are not attributed to it
-try {
-  base = git('merge-base', base, head).trim();
-} catch {
-  // e.g. shallow history; fall back to the base ref itself
-}
-
-let files = options.files;
-if (files.length === 0) {
-  const diffArgs = ['diff', '--name-only', '--diff-filter=ACMR', '--no-renames', base];
-  if (options.head != null) diffArgs.push(options.head);
-  files = git(...diffArgs).split('\n').filter(file => AGENDA_PATH_PATTERN.test(file));
-}
-if (files.length === 0) {
-  console.error('No agenda documents changed.');
-  process.exit(0);
-}
-
-let errorCount = 0;
-let runFailed = false;
-for (const file of files) {
-  const baseContents = tryGitShow(base, file);
-  let headContents;
-  if (options.head == null) {
-    try {
-      headContents = fs.readFileSync(file, 'utf8');
-    } catch {
-      console.error(`Cannot read '${file}' from the working tree.`);
-      process.exit(2);
-    }
-  } else {
-    headContents = tryGitShow(options.head, file);
-    if (headContents == null) {
-      console.error(`Cannot read '${file}' from '${options.head}'.`);
-      process.exit(2);
+// an IIFE so the early bailouts below can set process.exitCode and `return`;
+// setting the code rather than calling process.exit lets buffered annotation
+// output flush before the process ends (it can be truncated otherwise in CI)
+(() => {
+  const options = { base: null, head: null, strict: false, files: [] };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--base': options.base = argv[++i]; break;
+      case '--head': options.head = argv[++i]; break;
+      case '--strict': options.strict = true; break;
+      default: options.files.push(argv[i]);
     }
   }
-  const annotations = checkFile(baseContents, headContents);
-  for (const { kind, line, message } of annotations) {
-    if (RUN_FAILURE_KINDS.has(kind)) runFailed = true;
-    else if (SEVERITY[kind] === 'error') errorCount++;
-    const title = RUN_FAILURE_KINDS.has(kind) ? 'Proposals table not found' : 'Proposals table ordering';
-    // a run-failure annotation has no row to anchor to, so it is file-level
-    const location = line == null
-      ? `file=${escapeAnnotationProperty(file)}`
-      : `file=${escapeAnnotationProperty(file)},line=${line}`;
-    console.log(`::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`);
+  if (options.base == null) {
+    console.error('Usage: npm run check-proposals-order -- --base <ref> [--head <ref>] [--strict] [files...]');
+    process.exitCode = 2;
+    return;
   }
-  if (annotations.length === 0) {
-    console.error(`OK: ${file}`);
-  } else if (annotations.some(annotation => RUN_FAILURE_KINDS.has(annotation.kind))) {
-    console.error(`Could not check ${file}: no proposals table found.`);
-  } else {
-    console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
+
+  // run from the repo root so annotation paths are repo-relative
+  process.chdir(git('rev-parse', '--show-toplevel').trim());
+
+  let base;
+  try {
+    base = git('rev-parse', '--verify', `${options.base}^{commit}`).trim();
+  } catch {
+    console.error(`Cannot resolve base ref '${options.base}'.`);
+    process.exitCode = 2;
+    return;
   }
-}
-// a failure to run takes precedence over ordering violations
-if (runFailed) process.exit(2);
-if (options.strict && errorCount > 0) process.exit(1);
+  const head = options.head ?? 'HEAD'; // file contents still come from the working tree when --head is omitted
+  // compare against the fork point, so that changes merged to the base branch
+  // after this branch diverged are not attributed to it
+  try {
+    base = git('merge-base', base, head).trim();
+  } catch {
+    // e.g. shallow history; fall back to the base ref itself
+  }
+
+  let files = options.files;
+  if (files.length === 0) {
+    const diffArgs = ['diff', '--name-only', '--diff-filter=ACMR', '--no-renames', base];
+    if (options.head != null) diffArgs.push(options.head);
+    files = git(...diffArgs).split('\n').filter(file => AGENDA_PATH_PATTERN.test(file));
+  }
+  if (files.length === 0) {
+    console.error('No agenda documents changed.');
+    return;
+  }
+
+  let errorCount = 0;
+  let runFailed = false;
+  for (const file of files) {
+    const baseContents = tryGitShow(base, file);
+    let headContents;
+    if (options.head == null) {
+      try {
+        headContents = fs.readFileSync(file, 'utf8');
+      } catch {
+        console.error(`Cannot read '${file}' from the working tree.`);
+        process.exitCode = 2;
+        return;
+      }
+    } else {
+      headContents = tryGitShow(options.head, file);
+      if (headContents == null) {
+        console.error(`Cannot read '${file}' from '${options.head}'.`);
+        process.exitCode = 2;
+        return;
+      }
+    }
+    const annotations = checkFile(baseContents, headContents);
+    for (const { kind, line, message } of annotations) {
+      if (RUN_FAILURE_KINDS.has(kind)) runFailed = true;
+      else if (SEVERITY[kind] === 'error') errorCount++;
+      const title = RUN_FAILURE_KINDS.has(kind) ? 'Proposals table not found' : 'Proposals table ordering';
+      // a run-failure annotation has no row to anchor to, so it is file-level
+      const location = line == null
+        ? `file=${escapeAnnotationProperty(file)}`
+        : `file=${escapeAnnotationProperty(file)},line=${line}`;
+      console.log(`::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`);
+    }
+    if (annotations.length === 0) {
+      console.error(`OK: ${file}`);
+    } else if (annotations.some(annotation => RUN_FAILURE_KINDS.has(annotation.kind))) {
+      console.error(`Could not check ${file}: no proposals table found.`);
+    } else {
+      console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
+    }
+  }
+  // a failure to run takes precedence over ordering violations
+  if (runFailed) {
+    process.exitCode = 2;
+  } else if (options.strict && errorCount > 0) {
+    process.exitCode = 1;
+  }
+})();

--- a/scripts/check-proposals-order.cli.mjs
+++ b/scripts/check-proposals-order.cli.mjs
@@ -88,6 +88,7 @@ function escapeAnnotationProperty(text) {
         strict: { type: 'boolean', default: false },
       },
       allowPositionals: true,
+      allowNegative: true,
     }));
   } catch (error) {
     console.error(error.message);

--- a/scripts/check-proposals-order.mjs
+++ b/scripts/check-proposals-order.mjs
@@ -31,7 +31,7 @@ export function splitCells(line) {
   // the leading pipe produces an empty first element
   cells.shift();
   if (trimmed.endsWith('|')) cells.pop();
-  return cells.map(cell => cell.trim());
+  return cells.map((cell) => cell.trim());
 }
 
 export function parseStage(cell) {
@@ -60,11 +60,12 @@ export function parseProposalsTables(contents) {
   const tables = [];
   for (let i = 0; i < lines.length - 1; i++) {
     if (!/^\s*\|/.test(lines[i])) continue;
-    const headerCells = splitCells(lines[i]).map(cell => cell.toLowerCase());
+    const headerCells = splitCells(lines[i]).map((cell) => cell.toLowerCase());
     if (headerCells.length !== HEADER_CELLS.length) continue;
     if (!HEADER_CELLS.every((cell, k) => headerCells[k] === cell)) continue;
     if (!/^\s*\|/.test(lines[i + 1])) continue;
-    if (!splitCells(lines[i + 1]).every(cell => /^:?-+:?$/.test(cell))) continue;
+    if (!splitCells(lines[i + 1]).every((cell) => /^:?-+:?$/.test(cell)))
+      continue;
     const rows = [];
     let j = i + 2;
     for (; j < lines.length && /^\s*\|/.test(lines[j]); j++) {
@@ -98,9 +99,10 @@ export function findStaticViolations(rows) {
       if (earlier.stage < later.stage) {
         violations.push({ kind: 'stage', i, j });
       } else if (
-        earlier.stage === later.stage
-        && earlier.timebox != null && later.timebox != null
-        && earlier.timebox > later.timebox
+        earlier.stage === later.stage &&
+        earlier.timebox != null &&
+        later.timebox != null &&
+        earlier.timebox > later.timebox
       ) {
         violations.push({ kind: 'timebox', i, j });
       }
@@ -137,7 +139,7 @@ export function matchRows(baseRows, headRows) {
 // row whose stage/timebox was edited into violation is
 export function findNewStaticViolations(baseRows, headRows, headToBase) {
   const baseViolations = new Set(
-    findStaticViolations(baseRows).map(v => `${v.kind}:${v.i}:${v.j}`),
+    findStaticViolations(baseRows).map((v) => `${v.kind}:${v.i}:${v.j}`),
   );
   return findStaticViolations(headRows).filter(({ kind, i, j }) => {
     if (headToBase[i] == null || headToBase[j] == null) return true;
@@ -162,11 +164,13 @@ export function findInsertionViolations(baseRows, headRows, headToBase) {
     // rows that were already in this same group in the base table; a matched
     // row whose stage or timebox changed has an unknowable position among its
     // new peers, so it is exempt from the checks below
-    const existing = group.filter(h => {
+    const existing = group.filter((h) => {
       const b = headToBase[h];
-      return b != null
-        && baseRows[b].stage === headRows[h].stage
-        && baseRows[b].timebox === headRows[h].timebox;
+      return (
+        b != null &&
+        baseRows[b].stage === headRows[h].stage &&
+        baseRows[b].timebox === headRows[h].timebox
+      );
     });
     // existing rows must keep their base order: it records insertion date
     for (let x = 0; x < existing.length; x++) {
@@ -193,11 +197,13 @@ export function findInsertionViolations(baseRows, headRows, headToBase) {
 // row against four neighbours is four pairs. Anchor each pair on its likelier
 // culprit and merge pairs sharing an anchor into one message.
 function coalesceViolations(violations, baseRows, headRows, headToBase) {
-  const changed = h => {
+  const changed = (h) => {
     const b = headToBase[h];
-    return b == null
-      || baseRows[b].stage !== headRows[h].stage
-      || baseRows[b].timebox !== headRows[h].timebox;
+    return (
+      b == null ||
+      baseRows[b].stage !== headRows[h].stage ||
+      baseRows[b].timebox !== headRows[h].timebox
+    );
   };
   const grouped = new Map();
   for (const { kind, i, j } of violations) {
@@ -206,7 +212,10 @@ function coalesceViolations(violations, baseRows, headRows, headToBase) {
     // culprit first)
     let anchor = i;
     let other = j;
-    if ((kind === 'stage' || kind === 'timebox') && !(changed(i) && !changed(j))) {
+    if (
+      (kind === 'stage' || kind === 'timebox') &&
+      !(changed(i) && !changed(j))
+    ) {
       anchor = j;
       other = i;
     }
@@ -240,25 +249,32 @@ export function checkFile(baseContents, headContents) {
   // changed document without one means the table structure drifted and our
   // matching silently broke. Report it rather than passing vacuously.
   if (headTables.length === 0) {
-    return [{
-      kind: 'missing-table',
-      line: null,
-      message: 'No proposals table (a "| stage | timebox | topic | presenter |" table) was found, so its ordering could not be checked. If the table was renamed, moved, or its columns changed, update scripts/check-proposals-order.mjs to match.',
-    }];
+    return [
+      {
+        kind: 'missing-table',
+        line: null,
+        message:
+          'No proposals table (a "| stage | timebox | topic | presenter |" table) was found, so its ordering could not be checked. If the table was renamed, moved, or its columns changed, update scripts/check-proposals-order.mjs to match.',
+      },
+    ];
   }
-  const baseTables = baseContents == null ? [] : parseProposalsTables(baseContents);
+  const baseTables =
+    baseContents == null ? [] : parseProposalsTables(baseContents);
   const annotations = [];
   // pair base and head tables by order of appearance; an unpaired head table
   // (or a file absent from the base) has every row treated as newly added
   headTables.forEach((headTable, tableIndex) => {
-    const baseRows = tableIndex < baseTables.length ? baseTables[tableIndex].rows : [];
+    const baseRows =
+      tableIndex < baseTables.length ? baseTables[tableIndex].rows : [];
     const headRows = headTable.rows;
     const headToBase = matchRows(baseRows, headRows);
     const violations = [
       ...findNewStaticViolations(baseRows, headRows, headToBase),
       ...findInsertionViolations(baseRows, headRows, headToBase),
     ];
-    annotations.push(...coalesceViolations(violations, baseRows, headRows, headToBase));
+    annotations.push(
+      ...coalesceViolations(violations, baseRows, headRows, headToBase),
+    );
   });
   return annotations.sort((a, b) => a.line - b.line);
 }

--- a/scripts/check-proposals-order.mjs
+++ b/scripts/check-proposals-order.mjs
@@ -5,11 +5,16 @@
 // secondarily by timebox (ascending), and finally by insertion date.
 //
 // Problems are reported as GitHub workflow-command annotations (::error /
-// ::warning), which render inline on the PR diff; by default the script does
-// not fail for ordering problems, exiting non-zero only for usage or
-// environment errors. Pass --strict to exit 1 when any error-severity
-// problem is found (warnings never affect the exit code), for use in CI that
-// should block merging.
+// ::warning), which render inline on the PR diff. Exit codes:
+//   0  ran cleanly, or found only advisory ordering problems
+//   1  found error-severity ordering problems and --strict was passed
+//   2  could not run: bad usage, an unresolvable ref, an unreadable file, or
+//      a changed agenda document with no proposals table to check
+// Ordering problems do not fail the check by default so that we can gain
+// confidence in the absence of false positives before passing --strict to
+// block merging. A missing proposals table is not an ordering problem but a
+// failure to run — the table was renamed, moved, or its structure drifted
+// enough to break matching — so it always exits non-zero, --strict or not.
 //
 // The check is diff-aware: it compares against a base commit so that
 //   - violations already present in the base branch are tolerated (they are
@@ -40,16 +45,21 @@ import { pathToFileURL } from 'url';
 const HEADER_CELLS = ['stage', 'timebox', 'topic', 'presenter'];
 const AGENDA_PATH_PATTERN = /^\d{4}\/\d{2}\.md$/;
 
-// annotation severity per violation kind; purely presentational, since the
-// script never fails CI for ordering problems. Reordering rows of equal stage
-// and timebox may be a deliberate correction of a past mistake, which the
-// check cannot distinguish, so it only warrants a warning.
+// annotation severity per problem kind. For ordering violations this is
+// presentational, since they only fail CI under --strict; reordering rows of
+// equal stage and timebox may be a deliberate correction of a past mistake,
+// which the check cannot distinguish, so it only warrants a warning.
 const SEVERITY = {
   stage: 'error',
   timebox: 'error',
   insertion: 'error',
   reorder: 'warning',
+  'missing-table': 'error',
 };
+
+// kinds that mean the check could not run against a file rather than that it
+// found a violation; these fail the run unconditionally, even without --strict
+const RUN_FAILURE_KINDS = new Set(['missing-table']);
 
 // ---------- parsing ----------
 
@@ -262,6 +272,17 @@ function coalesceViolations(violations, baseRows, headRows, headToBase) {
 
 export function checkFile(baseContents, headContents) {
   const headTables = parseProposalsTables(headContents);
+  // Every current agenda document has a proposals table (it is in the
+  // template), and edits are made to the upcoming meeting's document, so a
+  // changed document without one means the table structure drifted and our
+  // matching silently broke. Report it rather than passing vacuously.
+  if (headTables.length === 0) {
+    return [{
+      kind: 'missing-table',
+      line: null,
+      message: 'No proposals table (a "| stage | timebox | topic | presenter |" table) was found, so its ordering could not be checked. If the table was renamed, moved, or its columns changed, update scripts/check-proposals-order.mjs to match.',
+    }];
+  }
   const baseTables = baseContents == null ? [] : parseProposalsTables(baseContents);
   const annotations = [];
   // pair base and head tables by order of appearance; an unpaired head table
@@ -349,6 +370,7 @@ function main() {
   }
 
   let errorCount = 0;
+  let runFailed = false;
   for (const file of files) {
     const baseContents = tryGitShow(base, file);
     let headContents;
@@ -368,15 +390,25 @@ function main() {
     }
     const annotations = checkFile(baseContents, headContents);
     for (const { kind, line, message } of annotations) {
-      if (SEVERITY[kind] === 'error') errorCount++;
-      console.log(`::${SEVERITY[kind]} file=${escapeAnnotationProperty(file)},line=${line},title=Proposals table ordering::${escapeAnnotationData(message)}`);
+      if (RUN_FAILURE_KINDS.has(kind)) runFailed = true;
+      else if (SEVERITY[kind] === 'error') errorCount++;
+      const title = RUN_FAILURE_KINDS.has(kind) ? 'Proposals table not found' : 'Proposals table ordering';
+      // a run-failure annotation has no row to anchor to, so it is file-level
+      const location = line == null
+        ? `file=${escapeAnnotationProperty(file)}`
+        : `file=${escapeAnnotationProperty(file)},line=${line}`;
+      console.log(`::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`);
     }
     if (annotations.length === 0) {
       console.error(`OK: ${file}`);
+    } else if (annotations.some(annotation => RUN_FAILURE_KINDS.has(annotation.kind))) {
+      console.error(`Could not check ${file}: no proposals table found.`);
     } else {
       console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
     }
   }
+  // a failure to run takes precedence over ordering violations
+  if (runFailed) process.exit(2);
   if (options.strict && errorCount > 0) process.exit(1);
 }
 

--- a/scripts/check-proposals-order.mjs
+++ b/scripts/check-proposals-order.mjs
@@ -90,7 +90,7 @@ export function parseTimebox(cell) {
 // was edited (e.g. a slides link was added)
 function firstTopicUrl(cells) {
   const match = /\]\(\s*<?([^)>\s]+)/.exec(cells[2] ?? '');
-  return match == null ? null : match[1];
+  return match?.[1];
 }
 
 // finds every proposals table: a `| stage | timebox | topic | presenter |`

--- a/scripts/check-proposals-order.mjs
+++ b/scripts/check-proposals-order.mjs
@@ -1,22 +1,13 @@
-#!/usr/bin/env node
-
-// Checks that changes to the "Proposals" table of an agenda document do not
-// violate its ordering rule: sorted primarily by stage (descending),
-// secondarily by timebox (ascending), and finally by insertion date.
+// The proposals-table ordering check for agenda documents. Given the base and
+// head contents of a document, `checkFile` returns the ordering problems that
+// the change under review introduces. The ordering rule is: sorted primarily
+// by stage (descending), secondarily by timebox (ascending), and finally by
+// insertion date.
 //
-// Problems are reported as GitHub workflow-command annotations (::error /
-// ::warning), which render inline on the PR diff. Exit codes:
-//   0  ran cleanly, or found only advisory ordering problems
-//   1  found error-severity ordering problems and --strict was passed
-//   2  could not run: bad usage, an unresolvable ref, an unreadable file, or
-//      a changed agenda document with no proposals table to check
-// Ordering problems do not fail the check by default so that we can gain
-// confidence in the absence of false positives before passing --strict to
-// block merging. A missing proposals table is not an ordering problem but a
-// failure to run — the table was renamed, moved, or its structure drifted
-// enough to break matching — so it always exits non-zero, --strict or not.
+// This module is pure logic with no I/O; the runnable entry point is
+// check-proposals-order.cli.mjs (the check-proposals-order npm script).
 //
-// The check is diff-aware: it compares against a base commit so that
+// The check is diff-aware: it compares against a base so that
 //   - violations already present in the base branch are tolerated (they are
 //     never forced to be cleaned up; only violations introduced by the change
 //     under review are reported), and
@@ -27,39 +18,8 @@
 // Rows with a non-numeric stage (e.g. "N/A") or an unparseable timebox are
 // unconstrained on that key. A renamed agenda document is treated as brand
 // new, so a grandfathered violation in it would resurface.
-//
-// Usage: node ./scripts/check-proposals-order.mjs --base <ref> [--head <ref>] [--strict] [files...]
-//   --base    base branch commit; the comparison point is `git merge-base
-//             <base> <head>`, i.e. the fork point
-//   --head    commit whose file contents to check; defaults to the working tree
-//   --strict  exit 1 if any error-severity ordering problem is found
-//   files     repo-relative agenda paths; defaults to the agenda documents
-//             changed between base and head
-//
-// Example: node ./scripts/check-proposals-order.mjs --base origin/main
-
-import { execFileSync } from 'child_process';
-import fs from 'fs';
-import { pathToFileURL } from 'url';
 
 const HEADER_CELLS = ['stage', 'timebox', 'topic', 'presenter'];
-const AGENDA_PATH_PATTERN = /^\d{4}\/\d{2}\.md$/;
-
-// annotation severity per problem kind. For ordering violations this is
-// presentational, since they only fail CI under --strict; reordering rows of
-// equal stage and timebox may be a deliberate correction of a past mistake,
-// which the check cannot distinguish, so it only warrants a warning.
-const SEVERITY = {
-  stage: 'error',
-  timebox: 'error',
-  insertion: 'error',
-  reorder: 'warning',
-  'missing-table': 'error',
-};
-
-// kinds that mean the check could not run against a file rather than that it
-// found a violation; these fail the run unconditionally, even without --strict
-const RUN_FAILURE_KINDS = new Set(['missing-table']);
 
 // ---------- parsing ----------
 
@@ -270,6 +230,9 @@ function coalesceViolations(violations, baseRows, headRows, headToBase) {
   });
 }
 
+// returns the ordering problems the head introduces relative to the base, as
+// { kind, line, message } objects (line is null for a whole-file problem).
+// A base of null means the document is new.
 export function checkFile(baseContents, headContents) {
   const headTables = parseProposalsTables(headContents);
   // Every current agenda document has a proposals table (it is in the
@@ -298,120 +261,4 @@ export function checkFile(baseContents, headContents) {
     annotations.push(...coalesceViolations(violations, baseRows, headRows, headToBase));
   });
   return annotations.sort((a, b) => a.line - b.line);
-}
-
-// ---------- CLI ----------
-
-function git(...args) {
-  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
-}
-
-function tryGitShow(commit, file) {
-  try {
-    return git('show', `${commit}:${file}`);
-  } catch {
-    return null;
-  }
-}
-
-// per https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
-function escapeAnnotationData(text) {
-  return text.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
-}
-
-function escapeAnnotationProperty(text) {
-  return escapeAnnotationData(text).replace(/:/g, '%3A').replace(/,/g, '%2C');
-}
-
-function main() {
-  const options = { base: null, head: null, strict: false, files: [] };
-  const argv = process.argv.slice(2);
-  for (let i = 0; i < argv.length; i++) {
-    switch (argv[i]) {
-      case '--base': options.base = argv[++i]; break;
-      case '--head': options.head = argv[++i]; break;
-      case '--strict': options.strict = true; break;
-      default: options.files.push(argv[i]);
-    }
-  }
-  if (options.base == null) {
-    console.error('Usage: check-proposals-order.mjs --base <ref> [--head <ref>] [--strict] [files...]');
-    process.exit(2);
-  }
-
-  // run from the repo root so annotation paths are repo-relative
-  process.chdir(git('rev-parse', '--show-toplevel').trim());
-
-  let base;
-  try {
-    base = git('rev-parse', '--verify', `${options.base}^{commit}`).trim();
-  } catch {
-    console.error(`Cannot resolve base ref '${options.base}'.`);
-    process.exit(2);
-  }
-  const head = options.head ?? 'HEAD'; // file contents still come from the working tree when --head is omitted
-  // compare against the fork point, so that changes merged to the base branch
-  // after this branch diverged are not attributed to it
-  try {
-    base = git('merge-base', base, head).trim();
-  } catch {
-    // e.g. shallow history; fall back to the base ref itself
-  }
-
-  let files = options.files;
-  if (files.length === 0) {
-    const diffArgs = ['diff', '--name-only', '--diff-filter=ACMR', '--no-renames', base];
-    if (options.head != null) diffArgs.push(options.head);
-    files = git(...diffArgs).split('\n').filter(file => AGENDA_PATH_PATTERN.test(file));
-  }
-  if (files.length === 0) {
-    console.error('No agenda documents changed.');
-    process.exit(0);
-  }
-
-  let errorCount = 0;
-  let runFailed = false;
-  for (const file of files) {
-    const baseContents = tryGitShow(base, file);
-    let headContents;
-    if (options.head == null) {
-      try {
-        headContents = fs.readFileSync(file, 'utf8');
-      } catch {
-        console.error(`Cannot read '${file}' from the working tree.`);
-        process.exit(2);
-      }
-    } else {
-      headContents = tryGitShow(options.head, file);
-      if (headContents == null) {
-        console.error(`Cannot read '${file}' from '${options.head}'.`);
-        process.exit(2);
-      }
-    }
-    const annotations = checkFile(baseContents, headContents);
-    for (const { kind, line, message } of annotations) {
-      if (RUN_FAILURE_KINDS.has(kind)) runFailed = true;
-      else if (SEVERITY[kind] === 'error') errorCount++;
-      const title = RUN_FAILURE_KINDS.has(kind) ? 'Proposals table not found' : 'Proposals table ordering';
-      // a run-failure annotation has no row to anchor to, so it is file-level
-      const location = line == null
-        ? `file=${escapeAnnotationProperty(file)}`
-        : `file=${escapeAnnotationProperty(file)},line=${line}`;
-      console.log(`::${SEVERITY[kind]} ${location},title=${title}::${escapeAnnotationData(message)}`);
-    }
-    if (annotations.length === 0) {
-      console.error(`OK: ${file}`);
-    } else if (annotations.some(annotation => RUN_FAILURE_KINDS.has(annotation.kind))) {
-      console.error(`Could not check ${file}: no proposals table found.`);
-    } else {
-      console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
-    }
-  }
-  // a failure to run takes precedence over ordering violations
-  if (runFailed) process.exit(2);
-  if (options.strict && errorCount > 0) process.exit(1);
-}
-
-if (process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
 }

--- a/scripts/check-proposals-order.mjs
+++ b/scripts/check-proposals-order.mjs
@@ -56,7 +56,7 @@ function firstTopicUrl(cells) {
 // finds every proposals table: a `| stage | timebox | topic | presenter |`
 // header (the only 4-column table in an agenda) followed by a delimiter row
 export function parseProposalsTables(contents) {
-  const lines = contents.replace(/\r\n/g, '\n').split('\n');
+  const lines = contents.split(/\r?\n/g);
   const tables = [];
   for (let i = 0; i < lines.length - 1; i++) {
     if (!/^\s*\|/.test(lines[i])) continue;

--- a/scripts/check-proposals-order.mjs
+++ b/scripts/check-proposals-order.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+
+// Checks that changes to the "Proposals" table of an agenda document do not
+// violate its ordering rule: sorted primarily by stage (descending),
+// secondarily by timebox (ascending), and finally by insertion date.
+//
+// Problems are reported as GitHub workflow-command annotations (::error /
+// ::warning), which render inline on the PR diff; by default the script does
+// not fail for ordering problems, exiting non-zero only for usage or
+// environment errors. Pass --strict to exit 1 when any error-severity
+// problem is found (warnings never affect the exit code), for use in CI that
+// should block merging.
+//
+// The check is diff-aware: it compares against a base commit so that
+//   - violations already present in the base branch are tolerated (they are
+//     never forced to be cleaned up; only violations introduced by the change
+//     under review are reported), and
+//   - the insertion-date rule can be enforced: it is not recorded in the
+//     table, so it only manifests as the relative order of rows sharing a
+//     stage and timebox. Newly added rows must come after pre-existing ones.
+//
+// Rows with a non-numeric stage (e.g. "N/A") or an unparseable timebox are
+// unconstrained on that key. A renamed agenda document is treated as brand
+// new, so a grandfathered violation in it would resurface.
+//
+// Usage: node ./scripts/check-proposals-order.mjs --base <ref> [--head <ref>] [--strict] [files...]
+//   --base    base branch commit; the comparison point is `git merge-base
+//             <base> <head>`, i.e. the fork point
+//   --head    commit whose file contents to check; defaults to the working tree
+//   --strict  exit 1 if any error-severity ordering problem is found
+//   files     repo-relative agenda paths; defaults to the agenda documents
+//             changed between base and head
+//
+// Example: node ./scripts/check-proposals-order.mjs --base origin/main
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import { pathToFileURL } from 'url';
+
+const HEADER_CELLS = ['stage', 'timebox', 'topic', 'presenter'];
+const AGENDA_PATH_PATTERN = /^\d{4}\/\d{2}\.md$/;
+
+// annotation severity per violation kind; purely presentational, since the
+// script never fails CI for ordering problems. Reordering rows of equal stage
+// and timebox may be a deliberate correction of a past mistake, which the
+// check cannot distinguish, so it only warrants a warning.
+const SEVERITY = {
+  stage: 'error',
+  timebox: 'error',
+  insertion: 'error',
+  reorder: 'warning',
+};
+
+// ---------- parsing ----------
+
+// splits a `| a | b |` table line into trimmed cell contents, respecting
+// escaped pipes and GFM's optional trailing pipe
+export function splitCells(line) {
+  const trimmed = line.trim();
+  const cells = trimmed.split(/(?<!\\)\|/);
+  // the leading pipe produces an empty first element
+  cells.shift();
+  if (trimmed.endsWith('|')) cells.pop();
+  return cells.map(cell => cell.trim());
+}
+
+export function parseStage(cell) {
+  return /^\d+(\.\d+)?$/.test(cell) ? parseFloat(cell) : null;
+}
+
+// timebox in minutes, e.g. "30m", "1h", "1h30m"
+export function parseTimebox(cell) {
+  const match = /^(?:(\d+)h)?(\d+)m$|^(\d+)h$/.exec(cell);
+  if (match == null) return null;
+  if (match[3] != null) return Number(match[3]) * 60;
+  return (match[1] == null ? 0 : Number(match[1]) * 60) + Number(match[2]);
+}
+
+// the first link URL in the topic cell, used to re-identify a row whose text
+// was edited (e.g. a slides link was added)
+function firstTopicUrl(cells) {
+  const match = /\]\(\s*<?([^)>\s]+)/.exec(cells[2] ?? '');
+  return match == null ? null : match[1];
+}
+
+// finds every proposals table: a `| stage | timebox | topic | presenter |`
+// header (the only 4-column table in an agenda) followed by a delimiter row
+export function parseProposalsTables(contents) {
+  const lines = contents.replace(/\r\n/g, '\n').split('\n');
+  const tables = [];
+  for (let i = 0; i < lines.length - 1; i++) {
+    if (!/^\s*\|/.test(lines[i])) continue;
+    const headerCells = splitCells(lines[i]).map(cell => cell.toLowerCase());
+    if (headerCells.length !== HEADER_CELLS.length) continue;
+    if (!HEADER_CELLS.every((cell, k) => headerCells[k] === cell)) continue;
+    if (!/^\s*\|/.test(lines[i + 1])) continue;
+    if (!splitCells(lines[i + 1]).every(cell => /^:?-+:?$/.test(cell))) continue;
+    const rows = [];
+    let j = i + 2;
+    for (; j < lines.length && /^\s*\|/.test(lines[j]); j++) {
+      const cells = splitCells(lines[j]);
+      rows.push({
+        line: j + 1, // 1-based
+        text: lines[j].trim(),
+        cells,
+        stage: parseStage(cells[0] ?? ''),
+        timebox: parseTimebox(cells[1] ?? ''),
+        url: firstTopicUrl(cells),
+      });
+    }
+    tables.push({ rows });
+    i = j - 1;
+  }
+  return tables;
+}
+
+// ---------- ordering checks ----------
+
+// all pairwise stage/timebox violations, so that a row with an unparseable
+// key sitting between two others cannot mask a violation across it
+export function findStaticViolations(rows) {
+  const violations = [];
+  for (let i = 0; i < rows.length; i++) {
+    for (let j = i + 1; j < rows.length; j++) {
+      const earlier = rows[i];
+      const later = rows[j];
+      if (earlier.stage == null || later.stage == null) continue;
+      if (earlier.stage < later.stage) {
+        violations.push({ kind: 'stage', i, j });
+      } else if (
+        earlier.stage === later.stage
+        && earlier.timebox != null && later.timebox != null
+        && earlier.timebox > later.timebox
+      ) {
+        violations.push({ kind: 'timebox', i, j });
+      }
+    }
+  }
+  return violations;
+}
+
+// pairs head rows with base rows: exact text first, then first topic link URL
+// (rows are routinely edited to add slides links); greedy and in document
+// order, so duplicates resolve deterministically
+export function matchRows(baseRows, headRows) {
+  const headToBase = new Array(headRows.length).fill(null);
+  const baseUsed = new Array(baseRows.length).fill(false);
+  for (const matches of [
+    (baseRow, headRow) => baseRow.text === headRow.text,
+    (baseRow, headRow) => headRow.url != null && baseRow.url === headRow.url,
+  ]) {
+    for (let h = 0; h < headRows.length; h++) {
+      if (headToBase[h] != null) continue;
+      for (let b = 0; b < baseRows.length; b++) {
+        if (baseUsed[b] || !matches(baseRows[b], headRows[h])) continue;
+        headToBase[h] = b;
+        baseUsed[b] = true;
+        break;
+      }
+    }
+  }
+  return headToBase;
+}
+
+// head violations minus those already present between the same two rows in
+// the base table: pre-existing problems are not this change's fault, but a
+// row whose stage/timebox was edited into violation is
+export function findNewStaticViolations(baseRows, headRows, headToBase) {
+  const baseViolations = new Set(
+    findStaticViolations(baseRows).map(v => `${v.kind}:${v.i}:${v.j}`),
+  );
+  return findStaticViolations(headRows).filter(({ kind, i, j }) => {
+    if (headToBase[i] == null || headToBase[j] == null) return true;
+    return !baseViolations.has(`${kind}:${headToBase[i]}:${headToBase[j]}`);
+  });
+}
+
+// enforces the insertion-date tiebreak within each group of head rows sharing
+// a (stage, timebox); these violations are inherently caused by the change
+// under review, so no suppression pass is needed
+export function findInsertionViolations(baseRows, headRows, headToBase) {
+  const violations = [];
+  const groups = new Map();
+  for (let h = 0; h < headRows.length; h++) {
+    const { stage, timebox } = headRows[h];
+    if (stage == null || timebox == null) continue;
+    const key = `${stage}:${timebox}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(h);
+  }
+  for (const group of groups.values()) {
+    // rows that were already in this same group in the base table; a matched
+    // row whose stage or timebox changed has an unknowable position among its
+    // new peers, so it is exempt from the checks below
+    const existing = group.filter(h => {
+      const b = headToBase[h];
+      return b != null
+        && baseRows[b].stage === headRows[h].stage
+        && baseRows[b].timebox === headRows[h].timebox;
+    });
+    // existing rows must keep their base order: it records insertion date
+    for (let x = 0; x < existing.length; x++) {
+      for (let y = x + 1; y < existing.length; y++) {
+        if (headToBase[existing[x]] > headToBase[existing[y]]) {
+          violations.push({ kind: 'reorder', i: existing[x], j: existing[y] });
+        }
+      }
+    }
+    // new rows were inserted last, so they must come after existing ones
+    for (const h of group) {
+      if (headToBase[h] != null) continue;
+      for (const e of existing) {
+        if (e > h) violations.push({ kind: 'insertion', i: h, j: e });
+      }
+    }
+  }
+  return violations;
+}
+
+// ---------- reporting ----------
+
+// pairwise checks produce a violation per pair, which is noisy: one misplaced
+// row against four neighbours is four pairs. Anchor each pair on its likelier
+// culprit and merge pairs sharing an anchor into one message.
+function coalesceViolations(violations, baseRows, headRows, headToBase) {
+  const changed = h => {
+    const b = headToBase[h];
+    return b == null
+      || baseRows[b].stage !== headRows[h].stage
+      || baseRows[b].timebox !== headRows[h].timebox;
+  };
+  const grouped = new Map();
+  for (const { kind, i, j } of violations) {
+    // anchor the added/edited row of the pair; when neither or both qualify,
+    // fall back to the later row (insertion/reorder pairs already put the
+    // culprit first)
+    let anchor = i;
+    let other = j;
+    if ((kind === 'stage' || kind === 'timebox') && !(changed(i) && !changed(j))) {
+      anchor = j;
+      other = i;
+    }
+    const key = `${kind}:${anchor}`;
+    if (!grouped.has(key)) grouped.set(key, { kind, anchor, others: [] });
+    grouped.get(key).others.push(other);
+  }
+  return [...grouped.values()].map(({ kind, anchor, others }) => {
+    others.sort((x, y) => headRows[x].line - headRows[y].line);
+    const row = headRows[anchor];
+    const counterpart = headRows[others[0]];
+    const more = others.length > 1 ? `, and ${others.length - 1} more` : '';
+    const relation = row.line < counterpart.line ? 'before' : 'after';
+    const messages = {
+      stage: `This stage ${row.stage} row appears ${relation} a stage ${counterpart.stage} row (line ${counterpart.line}${more}); proposals must be sorted by stage, descending.`,
+      timebox: `This ${row.cells[1]} row appears ${relation} a ${counterpart.cells[1]} row of the same stage (line ${counterpart.line}${more}); proposals of equal stage must be sorted by timebox, ascending.`,
+      insertion: `This newly added row appears before a pre-existing row of the same stage and timebox (line ${counterpart.line}${more}); rows of equal stage and timebox are sorted by insertion date, so new rows go after existing ones.`,
+      reorder: `This row appears ${relation} the row on line ${counterpart.line}${more}, but they are in the opposite order on the base branch; rows of equal stage and timebox are sorted by insertion date and must not be reordered.`,
+    };
+    return { kind, line: row.line, message: messages[kind] };
+  });
+}
+
+export function checkFile(baseContents, headContents) {
+  const headTables = parseProposalsTables(headContents);
+  const baseTables = baseContents == null ? [] : parseProposalsTables(baseContents);
+  const annotations = [];
+  // pair base and head tables by order of appearance; an unpaired head table
+  // (or a file absent from the base) has every row treated as newly added
+  headTables.forEach((headTable, tableIndex) => {
+    const baseRows = tableIndex < baseTables.length ? baseTables[tableIndex].rows : [];
+    const headRows = headTable.rows;
+    const headToBase = matchRows(baseRows, headRows);
+    const violations = [
+      ...findNewStaticViolations(baseRows, headRows, headToBase),
+      ...findInsertionViolations(baseRows, headRows, headToBase),
+    ];
+    annotations.push(...coalesceViolations(violations, baseRows, headRows, headToBase));
+  });
+  return annotations.sort((a, b) => a.line - b.line);
+}
+
+// ---------- CLI ----------
+
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function tryGitShow(commit, file) {
+  try {
+    return git('show', `${commit}:${file}`);
+  } catch {
+    return null;
+  }
+}
+
+// per https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+function escapeAnnotationData(text) {
+  return text.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function escapeAnnotationProperty(text) {
+  return escapeAnnotationData(text).replace(/:/g, '%3A').replace(/,/g, '%2C');
+}
+
+function main() {
+  const options = { base: null, head: null, strict: false, files: [] };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--base': options.base = argv[++i]; break;
+      case '--head': options.head = argv[++i]; break;
+      case '--strict': options.strict = true; break;
+      default: options.files.push(argv[i]);
+    }
+  }
+  if (options.base == null) {
+    console.error('Usage: check-proposals-order.mjs --base <ref> [--head <ref>] [--strict] [files...]');
+    process.exit(2);
+  }
+
+  // run from the repo root so annotation paths are repo-relative
+  process.chdir(git('rev-parse', '--show-toplevel').trim());
+
+  let base;
+  try {
+    base = git('rev-parse', '--verify', `${options.base}^{commit}`).trim();
+  } catch {
+    console.error(`Cannot resolve base ref '${options.base}'.`);
+    process.exit(2);
+  }
+  const head = options.head ?? 'HEAD'; // file contents still come from the working tree when --head is omitted
+  // compare against the fork point, so that changes merged to the base branch
+  // after this branch diverged are not attributed to it
+  try {
+    base = git('merge-base', base, head).trim();
+  } catch {
+    // e.g. shallow history; fall back to the base ref itself
+  }
+
+  let files = options.files;
+  if (files.length === 0) {
+    const diffArgs = ['diff', '--name-only', '--diff-filter=ACMR', '--no-renames', base];
+    if (options.head != null) diffArgs.push(options.head);
+    files = git(...diffArgs).split('\n').filter(file => AGENDA_PATH_PATTERN.test(file));
+  }
+  if (files.length === 0) {
+    console.error('No agenda documents changed.');
+    process.exit(0);
+  }
+
+  let errorCount = 0;
+  for (const file of files) {
+    const baseContents = tryGitShow(base, file);
+    let headContents;
+    if (options.head == null) {
+      try {
+        headContents = fs.readFileSync(file, 'utf8');
+      } catch {
+        console.error(`Cannot read '${file}' from the working tree.`);
+        process.exit(2);
+      }
+    } else {
+      headContents = tryGitShow(options.head, file);
+      if (headContents == null) {
+        console.error(`Cannot read '${file}' from '${options.head}'.`);
+        process.exit(2);
+      }
+    }
+    const annotations = checkFile(baseContents, headContents);
+    for (const { kind, line, message } of annotations) {
+      if (SEVERITY[kind] === 'error') errorCount++;
+      console.log(`::${SEVERITY[kind]} file=${escapeAnnotationProperty(file)},line=${line},title=Proposals table ordering::${escapeAnnotationData(message)}`);
+    }
+    if (annotations.length === 0) {
+      console.error(`OK: ${file}`);
+    } else {
+      console.error(`${annotations.length} ordering problem(s) introduced in ${file}`);
+    }
+  }
+  if (options.strict && errorCount > 0) process.exit(1);
+}
+
+if (process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-proposals-order.test.mjs
+++ b/scripts/check-proposals-order.test.mjs
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  checkFile,
+  findInsertionViolations,
+  findNewStaticViolations,
+  findStaticViolations,
+  matchRows,
+  parseProposalsTables,
+  parseStage,
+  parseTimebox,
+  splitCells,
+} from './check-proposals-order.mjs';
+
+// wraps proposal rows in a minimal agenda document, indented inside a list
+// item like the real thing
+function agenda(...rows) {
+  return [
+    '## Agenda items',
+    '',
+    '1. Short (≤30m) Timeboxed Discussions',
+    '',
+    '    | timebox | topic | presenter |',
+    '    |:-------:|-------|-----------|',
+    '    | 30m | a sibling table row that must be ignored | Alice |',
+    '',
+    '1. Proposals',
+    '',
+    '    | stage | timebox | topic | presenter |',
+    '    |:-----:|:-------:|-------|-----------|',
+    ...rows.map(row => `    ${row}`),
+    '',
+    '1. Other business',
+    '',
+  ].join('\n');
+}
+
+function proposalRows(contents) {
+  const tables = parseProposalsTables(contents);
+  assert.equal(tables.length, 1);
+  return tables[0].rows;
+}
+
+test('parseStage', () => {
+  assert.equal(parseStage('3'), 3);
+  assert.equal(parseStage('2.7'), 2.7);
+  assert.equal(parseStage('0'), 0);
+  assert.equal(parseStage('-'), null);
+  assert.equal(parseStage('N/A'), null);
+  assert.equal(parseStage('0 / 2'), null);
+  assert.equal(parseStage(''), null);
+});
+
+test('parseTimebox', () => {
+  assert.equal(parseTimebox('30m'), 30);
+  assert.equal(parseTimebox('5m'), 5);
+  assert.equal(parseTimebox('1h'), 60);
+  assert.equal(parseTimebox('1h30m'), 90);
+  assert.equal(parseTimebox('10-30m'), null);
+  assert.equal(parseTimebox('30'), null);
+  assert.equal(parseTimebox(''), null);
+});
+
+test('splitCells', () => {
+  assert.deepEqual(splitCells('| 1 | 30m | topic | presenter |'), ['1', '30m', 'topic', 'presenter']);
+  // GFM permits omitting the trailing pipe
+  assert.deepEqual(splitCells('| 1 | 30m | topic | presenter'), ['1', '30m', 'topic', 'presenter']);
+  // escaped pipes do not split cells
+  assert.deepEqual(splitCells('| 1 | 30m | a \\| b | presenter |'), ['1', '30m', 'a \\| b', 'presenter']);
+  // a stray unescaped pipe adds a cell but leaves the leading key cells alone
+  assert.deepEqual(splitCells('| 1 | 30m | a | b | presenter |'), ['1', '30m', 'a', 'b', 'presenter']);
+});
+
+test('parseProposalsTables finds only the 4-column proposals table', () => {
+  const contents = agenda(
+    '| 3 | 30m | [A](https://example.com/a) | Alice |',
+    '| 2 | 15m | [B](https://example.com/b) | Bob |',
+  );
+  const rows = proposalRows(contents);
+  assert.deepEqual(
+    rows.map(({ line, stage, timebox, url }) => ({ line, stage, timebox, url })),
+    [
+      { line: 13, stage: 3, timebox: 30, url: 'https://example.com/a' },
+      { line: 14, stage: 2, timebox: 15, url: 'https://example.com/b' },
+    ],
+  );
+});
+
+test('parseProposalsTables skips the legacy 5-column header', () => {
+  const contents = [
+    '    | ✓ | stage | timebox | topic | presenter |',
+    '    |:-:|:-----:|:-------:|-------|-----------|',
+    '    |   | 3 | 30m | A | Alice |',
+  ].join('\n');
+  assert.deepEqual(parseProposalsTables(contents), []);
+});
+
+test('parseProposalsTables handles an empty table fresh from the template', () => {
+  assert.deepEqual(proposalRows(agenda()), []);
+});
+
+test('static check accepts a correctly sorted table', () => {
+  const rows = proposalRows(agenda(
+    '| 3 | 30m | A | Alice |',
+    '| 2.7 | 30m | B | Bob |',
+    '| 2 | 30m | C | Carol |',
+    '| 2 | 45m | D | Dan |',
+    '| 1 | 20m | E | Erin |',
+    '| 0 | 60m | F | Frank |',
+  ));
+  assert.deepEqual(findStaticViolations(rows), []);
+});
+
+test('static check finds stage and timebox violations', () => {
+  const rows = proposalRows(agenda(
+    '| 2 | 30m | A | Alice |',
+    '| 3 | 30m | B | Bob |',
+    '| 2 | 15m | C | Carol |',
+  ));
+  assert.deepEqual(findStaticViolations(rows), [
+    { kind: 'stage', i: 0, j: 1 },
+    { kind: 'timebox', i: 0, j: 2 },
+  ]);
+});
+
+test('a row with unparseable keys does not mask violations across it', () => {
+  const rows = proposalRows(agenda(
+    '| 1 | 30m | A | Alice |',
+    '| N/A | 30m | B | Bob |',
+    '| 1 | 20m | C | Carol |',
+  ));
+  assert.deepEqual(findStaticViolations(rows), [{ kind: 'timebox', i: 0, j: 2 }]);
+});
+
+test('rows are matched by exact text, then by first topic link URL', () => {
+  const baseRows = proposalRows(agenda(
+    '| 2 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+  ));
+  const headRows = proposalRows(agenda(
+    '| 2 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [B](https://example.com/b) update ([slides](https://example.com/slides)) | Bob |',
+    '| 0 | 30m | [C](https://example.com/c) | Carol |',
+  ));
+  assert.deepEqual(matchRows(baseRows, headRows), [0, 1, null]);
+});
+
+test('duplicate-URL rows match deterministically, exact text first', () => {
+  const baseRows = proposalRows(agenda(
+    '| 2 | 30m | [A](https://example.com/a) part one | Alice |',
+    '| 2 | 45m | [A](https://example.com/a) part two | Alice |',
+  ));
+  const headRows = proposalRows(agenda(
+    '| 2 | 30m | [A](https://example.com/a) part one, edited | Alice |',
+    '| 2 | 45m | [A](https://example.com/a) part two | Alice |',
+  ));
+  // the exact-text pass claims row 1 for "part two"; the URL fallback then
+  // pairs the edited "part one" with the remaining base row
+  assert.deepEqual(matchRows(baseRows, headRows), [0, 1]);
+});
+
+test('pre-existing violations are suppressed, even when only the topic was edited', () => {
+  const base = agenda(
+    '| 2 | 60m | [A](https://example.com/a) | Alice |',
+    '| 2 | 30m | [B](https://example.com/b) | Bob |',
+  );
+  const untouched = checkFile(base, agenda(
+    '| 2 | 60m | [A](https://example.com/a) | Alice |',
+    '| 2 | 30m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+  ));
+  assert.deepEqual(untouched, []);
+  const topicEdited = checkFile(base, agenda(
+    '| 2 | 60m | [A](https://example.com/a) ([slides](https://example.com/slides)) | Alice |',
+    '| 2 | 30m | [B](https://example.com/b) | Bob |',
+  ));
+  assert.deepEqual(topicEdited, []);
+});
+
+test('editing a timebox into violation is attributed to the change', () => {
+  const base = agenda(
+    '| 2 | 30m | [A](https://example.com/a) | Alice |',
+    '| 2 | 45m | [B](https://example.com/b) | Bob |',
+  );
+  const head = agenda(
+    '| 2 | 60m | [A](https://example.com/a) | Alice |',
+    '| 2 | 45m | [B](https://example.com/b) | Bob |',
+  );
+  const annotations = checkFile(base, head);
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].kind, 'timebox');
+  assert.equal(annotations[0].line, 13);
+});
+
+test('a new row inserted above rows of the same stage with smaller timeboxes fails', () => {
+  // the shape of tc39/agendas#2125: a (1, 60m) row added at the top of the
+  // stage-1 block
+  const base = agenda(
+    '| 1 | 20m | [A](https://example.com/a) | Alice |',
+    '| 1 | 20m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+    '| 1 | 30m | [D](https://example.com/d) | Dan |',
+  );
+  const head = agenda(
+    '| 1 | 60m | [E](https://example.com/e) | Erin |',
+    '| 1 | 20m | [A](https://example.com/a) | Alice |',
+    '| 1 | 20m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+    '| 1 | 30m | [D](https://example.com/d) | Dan |',
+  );
+  const annotations = checkFile(base, head);
+  // four violating pairs coalesce into a single annotation on the new row
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].kind, 'timebox');
+  assert.equal(annotations[0].line, 13);
+  assert.match(annotations[0].message, /and 3 more/);
+  // and placing it at the end of the stage-1 block instead is clean
+  const fixed = agenda(
+    '| 1 | 20m | [A](https://example.com/a) | Alice |',
+    '| 1 | 20m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+    '| 1 | 30m | [D](https://example.com/d) | Dan |',
+    '| 1 | 60m | [E](https://example.com/e) | Erin |',
+  );
+  assert.deepEqual(checkFile(base, fixed), []);
+});
+
+test('a new row must come after existing rows of the same stage and timebox', () => {
+  const base = agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+  );
+  const inserted = checkFile(base, agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+  ));
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0].kind, 'insertion');
+  assert.equal(inserted[0].line, 14);
+  const appended = checkFile(base, agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+  ));
+  assert.deepEqual(appended, []);
+});
+
+test('reordering existing rows of the same stage and timebox fails', () => {
+  const base = agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+  );
+  const swapped = checkFile(base, agenda(
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+  ));
+  assert.equal(swapped.length, 1);
+  assert.equal(swapped[0].kind, 'reorder');
+});
+
+test('a row whose timebox changed is exempt from intra-group position checks', () => {
+  const base = agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 60m | [B](https://example.com/b) | Bob |',
+  );
+  // B's timebox shrinks to 30m and it lands before A; its insertion date
+  // relative to A is unknowable, so only static ordering applies
+  const regrouped = checkFile(base, agenda(
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+  ));
+  assert.deepEqual(regrouped, []);
+});
+
+test('a brand-new agenda document gets the static checks only', () => {
+  const misordered = checkFile(null, agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 2 | 30m | [B](https://example.com/b) | Bob |',
+  ));
+  assert.equal(misordered.length, 1);
+  assert.equal(misordered[0].kind, 'stage');
+  const clean = checkFile(null, agenda(
+    '| 2 | 30m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+    '| 1 | 30m | [C](https://example.com/c) | Carol |',
+  ));
+  assert.deepEqual(clean, []);
+});
+
+test('insertion violations report the new row, not the existing one', () => {
+  const baseRows = proposalRows(agenda(
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+  ));
+  const headRows = proposalRows(agenda(
+    '| 1 | 30m | [B](https://example.com/b) | Bob |',
+    '| 1 | 30m | [A](https://example.com/a) | Alice |',
+  ));
+  const headToBase = matchRows(baseRows, headRows);
+  assert.deepEqual(findInsertionViolations(baseRows, headRows, headToBase), [
+    { kind: 'insertion', i: 0, j: 1 },
+  ]);
+  assert.deepEqual(findNewStaticViolations(baseRows, headRows, headToBase), []);
+});

--- a/scripts/check-proposals-order.test.mjs
+++ b/scripts/check-proposals-order.test.mjs
@@ -36,6 +36,21 @@ function agenda(...rows) {
   ].join('\n');
 }
 
+// an agenda document whose proposals table our matcher would not find, e.g.
+// because its structure drifted (here, the header columns were renamed)
+function agendaWithoutProposals() {
+  return [
+    '## Agenda items',
+    '',
+    '1. Proposals',
+    '',
+    '    | stage | duration | topic | presenter |',
+    '    |:-----:|:--------:|-------|-----------|',
+    '    | 1 | 30m | [A](https://example.com/a) | Alice |',
+    '',
+  ].join('\n');
+}
+
 function proposalRows(contents) {
   const tables = parseProposalsTables(contents);
   assert.equal(tables.length, 1);
@@ -287,6 +302,23 @@ test('a brand-new agenda document gets the static checks only', () => {
     '| 1 | 30m | [C](https://example.com/c) | Carol |',
   ));
   assert.deepEqual(clean, []);
+});
+
+test('a changed document with no findable proposals table reports a run failure', () => {
+  const annotations = checkFile(agenda('| 1 | 30m | [A](https://example.com/a) | Alice |'), agendaWithoutProposals());
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].kind, 'missing-table');
+  assert.equal(annotations[0].line, null);
+});
+
+test('a brand-new document with no findable proposals table reports a run failure', () => {
+  const annotations = checkFile(null, agendaWithoutProposals());
+  assert.equal(annotations.length, 1);
+  assert.equal(annotations[0].kind, 'missing-table');
+});
+
+test('an empty table fresh from the template is found, not a run failure', () => {
+  assert.deepEqual(checkFile(null, agenda()), []);
 });
 
 test('insertion violations report the new row, not the existing one', () => {


### PR DESCRIPTION
In its current configuration, this will create inline annotations for any discovered violations using GitHub's [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands). In the future when we're more confident in the lack of false positives, we can pass `--strict` to fail CI for any violations.

Disclaimer: I used AI in the process of creating this PR.