### PR TITLE
2026.07: Add 402 editors' update slides

### DIFF
--- a/2026/07.md
+++ b/2026/07.md
@@ -87,7 +87,7 @@ When applicable, use these emoji as a prefix to the agenda item topic.
 1. Secretary's Report (15m, Samina Husain)
 1. Project Editors’ Reports
     1. [ECMA262](https://github.com/tc39/ecma262) Status Updates ([slides](https://docs.google.com/presentation/d/1uCpu8x8Fj0cZ41eQpygsS5uuX-xjiFKW0mxq6z2hTZQ)) (Michael Ficarra, 5m)
-    1. [ECMA402](https://github.com/tc39/ecma402) Status Updates (5m)
+    1. [ECMA402](https://github.com/tc39/ecma402) ([slides](https://www.ryzokuken.dev/slides/2026-07-ecma402)) Status Updates (Ujjwal Sharma, 5m)
     1. [ECMA404](https://www.ecma-international.org/publications/standards/Ecma-404.htm) Status Updates (1m)
     1. [Test262](https://github.com/tc39/test262) Status Updates (5m)
 1. Task Group Reports


### PR DESCRIPTION
Updated ECMA402 editorial status update slides link and presenter.